### PR TITLE
add make setup-dev and make run-pre-commit tools

### DIFF
--- a/libs/ai-endpoints/.pre-commit-config.yaml
+++ b/libs/ai-endpoints/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: https://github.com/python-poetry/poetry
+    rev: 1.7.1
+    hooks:
+      - id: poetry-check
+        args: ["--directory=libs/ai-endpoints"]
+      - id: poetry-lock
+        args: ["--directory=libs/ai-endpoints", "--no-update"]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.3
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+      - id: mypy

--- a/libs/ai-endpoints/Makefile
+++ b/libs/ai-endpoints/Makefile
@@ -18,6 +18,12 @@ check_imports: $(shell find langchain_nvidia_ai_endpoints -name '*.py')
 integration_tests:
 	poetry run pytest tests/integration_tests
 
+setup-dev:
+	poetry install --with dev,test,test_integration,lint
+	poetry run pre-commit install
+
+run-pre-commit:
+	poetry run pre-commit run --files langchain_nvidia_ai_endpoints/** tests/** scripts/**
 
 ######################
 # LINTING AND FORMATTING
@@ -60,3 +66,5 @@ help:
 	@echo 'test                         - run unit tests'
 	@echo 'tests                        - run unit tests'
 	@echo 'test TEST_FILE=<test_file>   - run all tests in file'
+	@echo 'setup-dev                    - install development env deps'
+	@echo 'run-pre-commit               - run pre-commit checks'

--- a/libs/ai-endpoints/pyproject.toml
+++ b/libs/ai-endpoints/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 "Source Code" = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/nvidia-ai-endpoints"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.9,<4.0"
 langchain-core = "^0.1.5"
 aiohttp = "^3.9.1"
 pillow = ">=10.0.0,<11.0.0"
@@ -56,6 +56,7 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 langchain-core = "^0.1.5"
+pre-commit = "^3.6.2"
 
 [tool.ruff.lint]
 select = [
@@ -95,3 +96,12 @@ markers = [
   "compile: mark placeholder test used to compile integration tests without running them",
 ]
 asyncio_mode = "auto"
+
+
+# line-length of 99? SPDX licenses headers are long.
+
+[tool.ruff]
+line-length = 99
+
+[tool.isort]
+line_length = 99


### PR DESCRIPTION
- install [pre-commit](https://pre-commit.com/) in development environment, assisted by `make setup-dev`
- configure pre-commit to run ruff, isort, poetry-check, mypy
- provide `make run-pre-commit` for checking across repository (pre-commit runs on committed files by default)

major change: require python `>=3.8.1,<4.0` to `>=3.9,<4.0` because pre-commit requires >=3.9