### PR TITLE
Fix missing api_key = None issue and try_raise parsing miss

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -277,7 +277,12 @@ class NVEModel(BaseModel):
                     except Exception:
                         rd = {"detail": rd}
             status = rd.get("status") or rd.get("status_code") or "###"
-            title = rd.get("title") or rd.get("error") or rd.get("reason") or "Unknown Error"
+            title = (
+                rd.get("title")
+                or rd.get("error")
+                or rd.get("reason")
+                or "Unknown Error"
+            )
             header = f"[{status}] {title}"
             body = ""
             if "requestId" in rd:

--- a/libs/ai-endpoints/tests/integration_tests/test_api_key.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_api_key.py
@@ -1,0 +1,27 @@
+import pytest
+
+from langchain_nvidia_ai_endpoints import ChatNVIDIA
+
+from ..unit_tests.test_api_key import no_env_var
+
+
+def test_missing_api_key_error() -> None:
+    with no_env_var("NVIDIA_API_KEY"):
+        chat = ChatNVIDIA()
+        with pytest.raises(ValueError) as exc_info:
+            chat.invoke("Hello, world!")
+        message = str(exc_info.value)
+        assert "401" in message
+        assert "Unauthorized" in message
+        assert "API key" in message
+
+
+def test_bogus_api_key_error() -> None:
+    with no_env_var("NVIDIA_API_KEY"):
+        chat = ChatNVIDIA(nvidia_api_key="BOGUS")
+        with pytest.raises(ValueError) as exc_info:
+            chat.invoke("Hello, world!")
+        message = str(exc_info.value)
+        assert "401" in message
+        assert "Unauthorized" in message
+        assert "API key" in message

--- a/libs/ai-endpoints/tests/unit_tests/test_api_key.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_api_key.py
@@ -1,0 +1,26 @@
+import os
+from contextlib import contextmanager
+from typing import Generator
+
+from langchain_nvidia_ai_endpoints import ChatNVIDIA, NVIDIAEmbeddings
+
+
+@contextmanager
+def no_env_var(var: str) -> Generator[None, None, None]:
+    try:
+        if key := os.environ.get(var, None):
+            del os.environ[var]
+            yield
+    finally:
+        if key:
+            os.environ[var] = key
+
+
+def test_create_chat_without_api_key() -> None:
+    with no_env_var("NVIDIA_API_KEY"):
+        ChatNVIDIA()
+
+
+def test_create_embeddings_without_api_key() -> None:
+    with no_env_var("NVIDIA_API_KEY"):
+        NVIDIAEmbeddings()

--- a/libs/ai-endpoints/tests/unit_tests/test_api_key.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_api_key.py
@@ -10,7 +10,7 @@ def no_env_var(var: str) -> Generator[None, None, None]:
     try:
         if key := os.environ.get(var, None):
             del os.environ[var]
-            yield
+        yield
     finally:
         if key:
             os.environ[var] = key


### PR DESCRIPTION
When a user tries to initialize a model without having an API key pulled in from the environment of constructor, it fails because the API key will be none. The one-line fix on top addresses this. 

An invalid key will cause an error from the server, and current code in try_raise will miss it due to a change in error message structure. A minimal modification is implemented to quickly remedy this. Further testing necessary later to see what all we might encounter in the error message space. 