### PR TITLE
add tests for NVIDIAEmbeddings().mode("nim", base_url="http://.../v1") support

### DIFF
--- a/libs/ai-endpoints/tests/integration_tests/conftest.py
+++ b/libs/ai-endpoints/tests/integration_tests/conftest.py
@@ -68,11 +68,16 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         if metafunc.config.getoption("embedding_model_id"):
             models = [metafunc.config.getoption("embedding_model_id")]
         if metafunc.config.getoption("all_models"):
-            models = [
-                model.id
-                for model in available_models
-                if model.model_type == "embedding"
-            ]
+            if mode.get("mode", None) == "nim":
+                # there is no guarantee the NIM will return a known model name,
+                # so we just grab all models and assume they are embeddings
+                models = [model.id for model in available_models]
+            else:
+                models = [
+                    model.id
+                    for model in available_models
+                    if model.model_type == "embedding"
+                ]
         metafunc.parametrize("embedding_model", models, ids=models)
 
 

--- a/libs/ai-endpoints/tests/integration_tests/test_embeddings.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_embeddings.py
@@ -9,50 +9,58 @@ import requests_mock
 from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings
 
 
-def test_nvai_play_embedding_documents(embedding_model: str) -> None:
+def test_nvai_play_embedding_documents(embedding_model: str, mode: dict) -> None:
     """Test NVIDIA embeddings for documents."""
     documents = ["foo bar"]
-    embedding = NVIDIAEmbeddings(model=embedding_model)
+    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
     output = embedding.embed_documents(documents)
     assert len(output) == 1
     assert len(output[0]) == 1024  # Assuming embedding size is 2048
 
 
-def test_nvai_play_embedding_documents_multiple(embedding_model: str) -> None:
+def test_nvai_play_embedding_documents_multiple(
+    embedding_model: str, mode: dict
+) -> None:
     """Test NVIDIA embeddings for multiple documents."""
     documents = ["foo bar", "bar foo", "foo"]
-    embedding = NVIDIAEmbeddings(model=embedding_model)
+    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
     output = embedding.embed_documents(documents)
     assert len(output) == 3
     assert all(len(doc) == 1024 for doc in output)
 
 
-def test_nvai_play_embedding_query(embedding_model: str) -> None:
+def test_nvai_play_embedding_query(embedding_model: str, mode: dict) -> None:
     """Test NVIDIA embeddings for a single query."""
     query = "foo bar"
-    embedding = NVIDIAEmbeddings(model=embedding_model)
+    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
     output = embedding.embed_query(query)
     assert len(output) == 1024
 
 
-async def test_nvai_play_embedding_async_query(embedding_model: str) -> None:
+async def test_nvai_play_embedding_async_query(
+    embedding_model: str, mode: dict
+) -> None:
     """Test NVIDIA async embeddings for a single query."""
     query = "foo bar"
-    embedding = NVIDIAEmbeddings(model=embedding_model)
+    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
     output = await embedding.aembed_query(query)
     assert len(output) == 1024
 
 
-async def test_nvai_play_embedding_async_documents(embedding_model: str) -> None:
+async def test_nvai_play_embedding_async_documents(
+    embedding_model: str, mode: dict
+) -> None:
     """Test NVIDIA async embeddings for multiple documents."""
     documents = ["foo bar", "bar foo", "foo"]
-    embedding = NVIDIAEmbeddings(model=embedding_model)
+    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
     output = await embedding.aembed_documents(documents)
     assert len(output) == 3
     assert all(len(doc) == 1024 for doc in output)
 
 
-def test_embed_available_models() -> None:
+def test_embed_available_models(mode: dict) -> None:
+    if mode:
+        pytest.skip(f"available_models test only valid against API Catalog, not {mode}")
     embedding = NVIDIAEmbeddings()
     models = embedding.available_models
     assert len(models) >= 2  # nvolveqa_40k and ai-embed-qa-4
@@ -73,25 +81,25 @@ def test_embed_available_models_cached() -> None:
         assert mock.call_count == 1
 
 
-def test_embed_long_query_text(embedding_model: str) -> None:
-    embedding = NVIDIAEmbeddings(model=embedding_model)
+def test_embed_long_query_text(embedding_model: str, mode: dict) -> None:
+    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
     text = "nvidia " * 2048
     with pytest.raises(Exception):
         embedding.embed_query(text)
 
 
-def test_embed_many_texts(embedding_model: str) -> None:
-    embedding = NVIDIAEmbeddings(model=embedding_model)
+def test_embed_many_texts(embedding_model: str, mode: dict) -> None:
+    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
     texts = ["nvidia " * 32] * 1000
     output = embedding.embed_documents(texts)
     assert len(output) == 1000
     assert all(len(embedding) == 1024 for embedding in output)
 
 
-def test_embed_mixed_long_texts(embedding_model: str) -> None:
+def test_embed_mixed_long_texts(embedding_model: str, mode: dict) -> None:
     if embedding_model == "nvolveqa_40k":
         pytest.skip("AI Foundation Model trucates by default")
-    embedding = NVIDIAEmbeddings(model=embedding_model)
+    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
     texts = ["nvidia " * 32] * 50
     texts[42] = "nvidia " * 2048
     with pytest.raises(Exception):


### PR DESCRIPTION
the existing code supports both NVIDIAEmbeddings communication with the NVIDIA API Catalog as well as a downloaded NVIDIA NIM.

this PR only provides test plumbing to validate the NIM support.

currently, there is no NIM CI infrastructure, so the tests must be run manually.

after setting up an embedding NIM on port 8082, use `poetry run pytest tests/integration_tests/test_embeddings.py --nim-endpoint http://localhost:8082/v1 --embedding-model-id NV-Embed-QA -vv`