### PR TITLE
add truncate parameter for shortening inputs to match model token length limits

### DIFF
--- a/libs/ai-endpoints/docs/text_embedding/nvidia_ai_endpoints.ipynb
+++ b/libs/ai-endpoints/docs/text_embedding/nvidia_ai_endpoints.ipynb
@@ -362,6 +362,81 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Truncation\n",
+    "\n",
+    "Embedding models typically have a fixed context window that determines the maximum number of input tokens that can be embedded. This limit could be a hard limit, equal to the model's maximum input token length, or an effective limit, beyond which the accuracy of the embedding decreases.\n",
+    "\n",
+    "Since models operate on tokens and applications usually work with text, it can be challenging for an application to ensure that its input stays within the model's token limits. By default, an exception is thrown if the input is too large.\n",
+    "\n",
+    "To assist with this, NVIDIA's NIMs (API Catalog or local) provide a `truncate` parameter that truncates the input on the server side if it's too large.\n",
+    "\n",
+    "The `truncate` parameter has three options:\n",
+    " - \"NONE\": The default option. An exception is thrown if the input is too large.\n",
+    " - \"START\": The server truncates the input from the start (left), discarding tokens as necessary.\n",
+    " - \"END\": The server truncates the input from the end (right), discarding tokens as necessary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "long_text = \"AI is amazing, amazing is \" * 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Error: [400] Bad Request\n",
+      "Inference error\n",
+      "RequestID: da4b59c2-93a9-4159-b28b-c0ae36d42355\n"
+     ]
+    }
+   ],
+   "source": [
+    "strict_embedder = NVIDIAEmbeddings()\n",
+    "try:\n",
+    "    strict_embedder.embed_query(long_text)\n",
+    "except Exception as e:\n",
+    "    print(\"Error:\", e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[-0.008758544921875,\n",
+       " 0.0009446144104003906,\n",
+       " -0.035064697265625,\n",
+       " 0.0254058837890625,\n",
+       " 0.00414276123046875]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "truncating_embedder = NVIDIAEmbeddings(truncate=\"END\")\n",
+    "truncating_embedder.embed_query(long_text)[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "RNIeY4N96v3B"
    },
@@ -376,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {
     "id": "zn_zeRGP64DJ"
    },
@@ -403,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -419,7 +494,7 @@
        "' Based on the document provided, Harrison worked at Kensho.'"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -455,7 +530,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -471,7 +546,7 @@
        "' Harrison ha lavorato presso Kensho.\\n\\nContext:\\n'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/libs/ai-endpoints/tests/integration_tests/test_embeddings.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_embeddings.py
@@ -102,6 +102,28 @@ def test_embed_documents_mixed_long_texts(embedding_model: str, mode: dict) -> N
         embedding.embed_documents(texts)
 
 
+@pytest.mark.parametrize("truncate", ["START", "END"])
+def test_embed_query_truncate(embedding_model: str, mode: dict, truncate: str) -> None:
+    if embedding_model == "nvolveqa_40k":
+        pytest.skip("AI Foundation Model does not support truncate option")
+    embedding = NVIDIAEmbeddings(model=embedding_model, truncate=truncate).mode(**mode)
+    text = "nvidia " * 2048
+    output = embedding.embed_query(text)
+    assert len(output) == 1024
+
+
+@pytest.mark.parametrize("truncate", ["START", "END"])
+def test_embed_documents_truncate(
+    embedding_model: str, mode: dict, truncate: str
+) -> None:
+    embedding = NVIDIAEmbeddings(model=embedding_model, truncate=truncate).mode(**mode)
+    count = 10
+    texts = ["nvidia " * 32] * count
+    texts[len(texts) // 2] = "nvidia " * 2048
+    output = embedding.embed_documents(texts)
+    assert len(output) == count
+
+
 # todo: test model_type ("passage" and embed_query,
 #                        "query" and embed_documents; compare results)
 # todo: test max_length > max length accepted by the model

--- a/libs/ai-endpoints/tests/unit_tests/test_embeddings.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_embeddings.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Generator
+from typing import Any, Generator
 
 import pytest
 from requests_mock import Mocker
@@ -93,5 +93,18 @@ def test_embed_deprecated_nvolvqa_40k() -> None:
         NVIDIAEmbeddings(model="playground_nvolveqa_40k")
 
 
-# todo: test max_length (-100, 0, 100)
+def test_embed_max_length_deprecated() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        NVIDIAEmbeddings()
+    with pytest.deprecated_call():
+        NVIDIAEmbeddings(max_length=43)
+
+
+@pytest.mark.parametrize("truncate", [True, False, 1, 0, 1.0, "BOGUS"])
+def test_embed_query_truncate_invalid(truncate: Any) -> None:
+    with pytest.raises(ValueError):
+        NVIDIAEmbeddings(truncate=truncate)
+
+
 # todo: test max_batch_size (-50, 0, 1, 50)


### PR DESCRIPTION
options are -
 - "NONE" (default), do not truncate and raise an exception if the input is too long
 - "END", truncate tokens from the right side of the input
 - "START", truncate tokens from the left side of the input

future: consider END/RIGHT/BOTTOM and START/LEFT/TOP aliases for better language support

note: NONE is the default because it is the service's default, most users will pick END

fixes #20 