### PR TITLE
add NVIDIARerank support for a local NIM

### DIFF
--- a/libs/ai-endpoints/docs/retrievers/nvidia_rerank.ipynb
+++ b/libs/ai-endpoints/docs/retrievers/nvidia_rerank.ipynb
@@ -17,7 +17,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Combining results from multiple sources\n",
+    "## Working with NVIDIA NIMs\n",
+    "\n",
+    "[ai.nvidia.com](http://ai.nvidia.com) hosts a variety of AI models accessible with an api key and the `langchain-nvidia-ai-endpoints` library. The use cases below operate in this mode by default."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Combining results from multiple sources\n",
     "\n",
     "Consider a pipeline with data from a semantic store, such as FAISS, as well as a BM25 store.\n",
     "\n",
@@ -52,7 +61,7 @@
     }
    },
    "source": [
-    "### BM25 relevant documents\n",
+    "#### BM25 relevant documents\n",
     "\n",
     "Below we assume you have ElasticSearch running with documents stored in a `langchain-index` store."
    ]
@@ -106,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Semantic documents\n",
+    "#### Semantic documents\n",
     "\n",
     "Below we assume you have a saved FAISS index."
    ]
@@ -137,7 +146,7 @@
     "from langchain_community.vectorstores import FAISS\n",
     "from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings\n",
     "\n",
-    "embeddings = NVIDIAEmbeddings()\n",
+    "embedder = NVIDIAEmbeddings()\n",
     "\n",
     "# De-serialization relies on loading a pickle file.\n",
     "# Pickle files can be modified to deliver a malicious payload that\n",
@@ -167,7 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Combine and rank documents\n",
+    "#### Combine and rank documents\n",
     "\n",
     "The resulting `docs` will be ordered by their relevance to the query."
    ]
@@ -195,7 +204,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Enhancing accuracy for single data sources\n",
+    "### Enhancing accuracy for single data sources\n",
     "\n",
     "Semantic search with vector embeddings is an efficient way to turn a large corpus of documents into a smaller corpus of relevant documents. This is done by trading accuracy for efficiency. Reranking as a tool adds accuracy back into the search by post-processing the smaller corpus of documents. Typically, ranking on the full corpus is too slow for applications."
    ]
@@ -236,15 +245,50 @@
     "from langchain.vectorstores.pgvector import PGVector\n",
     "\n",
     "ranker = NVIDIARerank(top_n=10)\n",
-    "embeddings = NVIDIAEmbeddings()\n",
+    "embedder = NVIDIAEmbeddings()\n",
     "\n",
-    "store = PGVector(embeddings=embeddings,\n",
+    "store = PGVector(embeddings=embedder,\n",
     "                 collection_name=\"langchain-index\",\n",
     "                 connection=\"postgresql+psycopg://langchain:langchain@localhost:6024/langchain\")\n",
     "\n",
     "subset_docs = store.similarity_search(query, k=1_000)\n",
     "\n",
     "docs = ranker.compress_documents(query=query, documents=subset_docs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with a local NIM\n",
+    "\n",
+    "[Learn more about NIMs](https://developer.nvidia.com/blog/nvidia-nim-offers-optimized-inference-microservices-for-deploying-ai-models-at-scale/)\n",
+    "\n",
+    "The `NVIDIAEmbeddings` and `NVIDIARerank` classes give you a way to work with local NIMs through `mode` switching."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# connect to an embedding NIM running at localhost:2016\n",
+    "embedder = NVIDIAEmbeddings().mode(\"nim\", base_url=\"http://localhost:2016/v1\")\n",
+    "\n",
+    "# connect to a reranking NIM running at localhost:1976\n",
+    "ranker = NVIDIARerank().mode(\"nim\", base_url=\"http://localhost:1976/v1\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can rerun the examples above with this new `embedder` and `ranker`."
    ]
   }
  ],

--- a/libs/ai-endpoints/tests/integration_tests/test_ranking.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_ranking.py
@@ -7,6 +7,7 @@ from langchain_core.documents import Document
 from requests.exceptions import ConnectionError, MissingSchema
 
 from langchain_nvidia_ai_endpoints import NVIDIARerank  # type: ignore
+from langchain_nvidia_ai_endpoints._common import Model
 
 
 class CharacterTextSplitter:
@@ -42,6 +43,30 @@ def splitter() -> CharacterTextSplitter:
 @pytest.fixture
 def documents(text: str, splitter: CharacterTextSplitter) -> List[Document]:
     return splitter.create_documents(text)
+
+
+def test_langchain_reranker_get_available_models(mode: dict) -> None:
+    models = NVIDIARerank.get_available_models(**mode)
+    assert len(models) > 0
+    for model in models:
+        assert isinstance(model, Model)
+        assert model.model_type == "ranking" or model.model_type is None
+
+
+def test_langchain_reranker_get_available_models_all(mode: dict) -> None:
+    models = NVIDIARerank.get_available_models(**mode, list_all=True)
+    assert len(models) > 0
+    for model in models:
+        assert isinstance(model, Model)
+
+
+def test_langchain_reranker_available_models(mode: dict) -> None:
+    ranker = NVIDIARerank().mode(**mode)
+    models = ranker.available_models
+    assert len(models) > 0
+    for model in models:
+        assert isinstance(model, Model)
+        assert model.model_type == "ranking" or model.model_type is None
 
 
 def test_langchain_reranker_direct(


### PR DESCRIPTION
this is an extension of the NVIDIARerank api to work with a local NIM, all expectations about NVIDIARerank persist plus the following -

```
# connect to a reranking NIM running at localhost:1976
ranker = NVIDIARerank().mode("nim", base_url="http://localhost:1976/v1")
```

this builds off #19 