### PR TITLE
vanity model name support

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -183,6 +183,16 @@ class NVEModel(BaseModel):
             raise ValueError(
                 f"Unexpected response when querying {invoke_url}\n{query_res}"
             )
+        # if there's an alias / model name for the function, add it as well
+        # this lets users work with ai-gemma-2b and google/gemma-2b
+        aliases = []
+        for function in output:
+            name = function["name"]
+            if name in MODEL_SPECS and "model_name" in MODEL_SPECS[name]:
+                alias = function.copy()
+                alias.update(name=MODEL_SPECS[name]["model_name"])
+                aliases.append(alias)
+        output.extend(aliases)
         self._available_functions = output
         return self._available_functions
 

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -33,7 +33,11 @@ MODEL_SPECS = {
         "alternative": "mistralai/mistral-7b-instruct-v0.2",
     },
     "playground_mamba_chat": {"model_type": "chat", "api_type": "aifm"},
-    "playground_phi2": {"model_type": "chat", "api_type": "aifm"},
+    "playground_phi2": {
+        "model_type": "chat",
+        "api_type": "aifm",
+        "alternative": "microsoft/phi-3-mini-128k-instruct",
+    },
     "playground_sdxl": {"model_type": "image_out", "api_type": "aifm"},
     "playground_nv_llama2_rlhf_70b": {"model_type": "chat", "api_type": "aifm"},
     "playground_neva_22b": {

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -18,19 +18,19 @@ MODEL_SPECS = {
     "playground_llama2_70b": {
         "model_type": "chat",
         "api_type": "aifm",
-        "alternative": "ai-llama2-70b",
+        "alternative": "meta/llama2-70b",
     },
     "playground_nvolveqa_40k": {"model_type": "embedding", "api_type": "aifm"},
     "playground_nemotron_qa_8b": {"model_type": "qa", "api_type": "aifm"},
     "playground_gemma_7b": {
         "model_type": "chat",
         "api_type": "aifm",
-        "alternative": "ai-gemma-7b",
+        "alternative": "google/gemma-7b",
     },
     "playground_mistral_7b": {
         "model_type": "chat",
         "api_type": "aifm",
-        "alternative": "ai-mistral-7b-instruct-v2",
+        "alternative": "mistralai/mistral-7b-instruct-v0.2",
     },
     "playground_mamba_chat": {"model_type": "chat", "api_type": "aifm"},
     "playground_phi2": {"model_type": "chat", "api_type": "aifm"},
@@ -54,18 +54,18 @@ MODEL_SPECS = {
     "playground_llama2_code_70b": {
         "model_type": "chat",
         "api_type": "aifm",
-        "alternative": "ai-codellama-70b",
+        "alternative": "meta/codelama-70b",
     },
     "playground_gemma_2b": {
         "model_type": "chat",
         "api_type": "aifm",
-        "alternative": "ai-gemma-2b",
+        "alternative": "google/gemma-2b",
     },
     "playground_seamless": {"model_type": "translation", "api_type": "aifm"},
     "playground_mixtral_8x7b": {
         "model_type": "chat",
         "api_type": "aifm",
-        "alternative": "ai-mixtral-8x7b-instruct",
+        "alternative": "mistralai/mixtral-8x7b-instruct-v0.1",
     },
     "playground_fuyu_8b": {
         "model_type": "image_in",
@@ -75,19 +75,19 @@ MODEL_SPECS = {
     "playground_llama2_code_34b": {
         "model_type": "chat",
         "api_type": "aifm",
-        "alternative": "ai-codellama-70b",
+        "alternative": "meta/codellama-70b",
     },
     "playground_llama2_code_13b": {
         "model_type": "chat",
         "api_type": "aifm",
-        "alternative": "ai-codellama-70b",
+        "alternative": "meta/codellama-70b",
     },
     "playground_steerlm_llama_70b": {"model_type": "chat", "api_type": "aifm"},
     "playground_clip": {"model_type": "similarity", "api_type": "aifm"},
     "playground_llama2_13b": {
         "model_type": "chat",
         "api_type": "aifm",
-        "alternative": "ai-llama2-70b",
+        "alternative": "meta/llama2-70b",
     },
 }
 
@@ -202,3 +202,7 @@ client_map = {
 MODEL_SPECS = {
     k: {**v, "client": client_map[v["model_type"]]} for k, v in MODEL_SPECS.items()
 }
+# MODEL_SPEC database should have both function and model names
+MODEL_SPECS.update(
+    {v["model_name"]: v for v in MODEL_SPECS.values() if "model_name" in v}
+)

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -20,7 +20,11 @@ MODEL_SPECS = {
         "api_type": "aifm",
         "alternative": "meta/llama2-70b",
     },
-    "playground_nvolveqa_40k": {"model_type": "embedding", "api_type": "aifm"},
+    "playground_nvolveqa_40k": {
+        "model_type": "embedding",
+        "api_type": "aifm",
+        "alternative": "NV-Embed-QA",
+    },
     "playground_nemotron_qa_8b": {"model_type": "qa", "api_type": "aifm"},
     "playground_gemma_7b": {
         "model_type": "chat",

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -130,7 +130,7 @@ class ChatNVIDIA(nvidia_ai_endpoints._NVIDIAClient, BaseChatModel):
             response = model.invoke("Hello")
     """
 
-    _default_model: str = "ai-mixtral-8x7b-instruct"
+    _default_model: str = "mistralai/mixtral-8x7b-instruct-v0.1"
     infer_endpoint: str = Field("{base_url}/chat/completions")
     model: str = Field(_default_model, description="Name of the model to invoke")
     temperature: Optional[float] = Field(description="Sampling temperature in [0, 1]")

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
@@ -24,7 +24,7 @@ class NVIDIAEmbeddings(_NVIDIAClient, Embeddings):
         too long.
     """
 
-    _default_model: str = "ai-embed-qa-4"
+    _default_model: str = "NV-Embed-QA"
     _default_max_batch_size: int = 50
     infer_endpoint: str = Field("{base_url}/embeddings")
     model: str = Field(_default_model, description="Name of the model to invoke")

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
@@ -56,13 +56,17 @@ class NVIDIAEmbeddings(_NVIDIAClient, Embeddings):
 
     # todo: fix _NVIDIAClient.validate_client and enable Config.validate_assignment
     @validator("model")
-    def deprecated_nvolveqa_40k(cls, value: str) -> str:
-        """Deprecate the nvolveqa_40k model."""
-        if value == "nvolveqa_40k" or value == "playground_nvolveqa_40k":
-            warnings.warn(
-                "nvolveqa_40k is deprecated. Use ai-embed-qa-4 instead.",
-                DeprecationWarning,
-            )
+    def aifm_deprecated(cls, value: str) -> str:
+        """All AI Foundataion Models are deprecate, use API Catalog models instead."""
+        for model in [value, f"playground_{value}"]:
+            if model in MODEL_SPECS and MODEL_SPECS[model].get("api_type") == "aifm":
+                alternative = MODEL_SPECS[model].get(
+                    "alternative", NVIDIAEmbeddings._default_model
+                )
+                warnings.warn(
+                    f"{value} is deprecated. Try {alternative} instead.",
+                    DeprecationWarning,
+                )
         return value
 
     def _embed(

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
@@ -27,11 +27,13 @@ class NVIDIARerank(BaseDocumentCompressor):
     _client: _NVIDIAClient = PrivateAttr(_NVIDIAClient)
 
     _default_batch_size: int = 32
-    _default_model: str = "ai-rerank-qa-mistral-4b"
+    _deprecated_model: str = "ai-rerank-qa-mistral-4b"
     _default_model_name: str = "nv-rerank-qa-mistral-4b:1"
 
     top_n: int = Field(5, ge=0, description="The number of documents to return.")
-    model: str = Field(_default_model, description="The model to use for reranking.")
+    model: str = Field(
+        _default_model_name, description="The model to use for reranking."
+    )
     max_batch_size: int = Field(
         _default_batch_size, ge=1, description="The maximum batch size."
     )
@@ -62,12 +64,19 @@ class NVIDIARerank(BaseDocumentCompressor):
             # local NIM supports a single model and no /models endpoint
             models = [
                 Model(
-                    id=NVIDIARerank._default_model,
+                    id=NVIDIARerank._default_model_name,
                     model_name=NVIDIARerank._default_model_name,
                     model_type="ranking",
                     client="NVIDIARerank",
                     path="magic",
-                )
+                ),
+                Model(
+                    id=NVIDIARerank._deprecated_model,
+                    model_name=NVIDIARerank._default_model_name,
+                    model_type="ranking",
+                    client="NVIDIARerank",
+                    path="magic",
+                ),
             ]
         else:
             models = self._client.get_available_models(


### PR DESCRIPTION
model names are currently things like `playground_llama2-70b` or `ai-llama3-70b`, these are not the proper names for the models. `ai-llama3-70b` is the name of a cloud function that serves the `meta/llama3-70b-instruct` model.

with this change the proper model names can be used along side the function name, for compatibility.

```python
llm = ChatNVIDIA(model="ai-llama3-70b")
```
is equivalent to
```python
llm = ChatNVIDIA(model="meta/llama3-70b-instruct")
```
