### PR TITLE
Deprecate mode() in favor of __init__(base_url=...)

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -22,7 +22,7 @@ from typing import (
 
 import aiohttp
 import requests
-from langchain_core._api import deprecated
+from langchain_core._api import deprecated, warn_deprecated
 from langchain_core.pydantic_v1 import (
     BaseModel,
     Field,
@@ -534,7 +534,17 @@ class _NVIDIAClient(BaseModel):
     _default_model: str = ""
     model: str = Field(description="Name of the model to invoke")
     infer_endpoint: str = Field("{base_url}/chat/completions")
-    curr_mode: _MODE_TYPE = Field("nvidia")
+    curr_mode: _MODE_TYPE = Field("nvidia")  # todo: remove this in 0.1
+    is_hosted: bool = Field(True)
+
+    def __init__(self, base_url: Optional[str] = None, **kwargs: Any):
+        super().__init__(**kwargs)
+        if base_url:
+            self.is_hosted = False
+            self.curr_mode = "nim"
+            self.client.base_url = base_url
+            self.client.endpoints["infer"] = self.infer_endpoint
+            self.client.endpoints["models"] = "{base_url}/models"
 
     ####################################################################################
 
@@ -595,9 +605,9 @@ class _NVIDIAClient(BaseModel):
     @property
     def available_models(self) -> List[Model]:
         """Map the available models that can be invoked."""
-        if self.curr_mode == "nim":
+        if self.curr_mode == "nim" or not self.is_hosted:
             return self.__class__.get_available_models(
-                client=self, mode="nim", base_url=self.client.base_url
+                client=self, base_url=self.client.base_url
             )
         else:
             return self.__class__.get_available_models(client=self)
@@ -625,7 +635,12 @@ class _NVIDIAClient(BaseModel):
         **kwargs: Any,
     ) -> List[Model]:
         """Map the available models that can be invoked. Callable from class"""
-        nveclient = (client or cls(**kwargs)).mode(mode, **kwargs).client
+        if mode is not None:
+            warn_deprecated(
+                name="mode", since="0.0.17", removal="0.1.0", alternative="`base_url`"
+            )
+        self = client or cls(**kwargs)
+        nveclient = self.client
         nveclient.reset_method_cache()
         out = sorted(
             [
@@ -637,7 +652,7 @@ class _NVIDIAClient(BaseModel):
         # nim model listing does not provide the type and we cannot know
         # the model name ahead of time to guess the type.
         # so we need to list all models.
-        if mode == "nim":
+        if mode == "nim" or not self.is_hosted:
             list_all = True
         if not filter:
             filter = cls.__name__
@@ -668,6 +683,11 @@ class _NVIDIAClient(BaseModel):
             return ""
         return self.model
 
+    @deprecated(
+        since="0.0.17",
+        removal="0.1.0",
+        alternative="`base_url` in constructor",
+    )
     def mode(
         self,
         mode: Optional[_MODE_TYPE] = "nvidia",
@@ -680,7 +700,7 @@ class _NVIDIAClient(BaseModel):
         force_clone: bool = True,
         **kwargs: Any,
     ) -> Any:  # todo: in python 3.11+ this should be typing.Self
-        """Return a client swapped to a different mode"""
+        """Deprecated: pass `base_url=...` to constructor instead."""
         if isinstance(self, str):
             raise ValueError("Please construct the model before calling mode()")
         out = self if not force_clone else deepcopy(self)

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
@@ -142,7 +142,7 @@ class NVIDIARerank(BaseDocumentCompressor):
     @deprecated(
         since="0.0.17",
         removal="0.1.0",
-        alternative="pas `base_url` to constructor",
+        alternative="`base_url` to constructor",
     )
     def mode(
         self,

--- a/libs/ai-endpoints/pyproject.toml
+++ b/libs/ai-endpoints/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-nvidia-ai-endpoints"
-version = "0.0.17"
+version = "0.0.18"
 description = "An integration package connecting NVIDIA AI Endpoints and LangChain"
 authors = []
 readme = "README.md"

--- a/libs/ai-endpoints/tests/integration_tests/conftest.py
+++ b/libs/ai-endpoints/tests/integration_tests/conftest.py
@@ -9,7 +9,7 @@ from langchain_nvidia_ai_endpoints._common import Model
 def get_mode(config: pytest.Config) -> dict:
     nim_endpoint = config.getoption("--nim-endpoint")
     if nim_endpoint:
-        return dict(mode="nim", base_url=nim_endpoint)
+        return dict(base_url=nim_endpoint)
     return {}
 
 
@@ -50,14 +50,14 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     mode = get_mode(metafunc.config)
 
     def get_all_models() -> List[Model]:
-        return ChatNVIDIA().mode(**mode).get_available_models(list_all=True, **mode)
+        return ChatNVIDIA.get_available_models(list_all=True, **mode)
 
     if "chat_model" in metafunc.fixturenames:
         models = [ChatNVIDIA._default_model]
         if model := metafunc.config.getoption("chat_model_id"):
             models = [model]
         if metafunc.config.getoption("all_models"):
-            models = [model.id for model in ChatNVIDIA().mode(**mode).available_models]
+            models = [model.id for model in ChatNVIDIA(**mode).available_models]
         metafunc.parametrize("chat_model", models, ids=models)
 
     if "rerank_model" in metafunc.fixturenames:
@@ -67,9 +67,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         # nim-mode reranking does not support model listing via /v1/models endpoint
         if metafunc.config.getoption("all_models"):
             if mode.get("mode", None) == "nim":
-                models = [
-                    model.id for model in NVIDIARerank().mode(**mode).available_models
-                ]
+                models = [model.id for model in NVIDIARerank(**mode).available_models]
             else:
                 models = [
                     model.id

--- a/libs/ai-endpoints/tests/integration_tests/test_embeddings.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_embeddings.py
@@ -5,6 +5,7 @@ Note: These tests are designed to validate the functionality of NVIDIAEmbeddings
 
 import pytest
 import requests_mock
+from langchain_core._api import LangChainDeprecationWarning
 
 from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings
 
@@ -12,44 +13,53 @@ from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings
 def test_embed_query(embedding_model: str, mode: dict) -> None:
     """Test NVIDIA embeddings for a single query."""
     query = "foo bar"
-    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
+    embedding = NVIDIAEmbeddings(model=embedding_model, **mode)
     output = embedding.embed_query(query)
-    assert len(output) == 1024
+    assert len(output) > 3
+
+
+def test_embed_query_deprecated(embedding_model: str, mode: dict) -> None:
+    """Test NVIDIA embeddings for a single query."""
+    query = "foo bar"
+    with pytest.warns(LangChainDeprecationWarning):
+        embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
+    output = embedding.embed_query(query)
+    assert len(output) > 3
 
 
 async def test_embed_query_async(embedding_model: str, mode: dict) -> None:
     """Test NVIDIA async embeddings for a single query."""
     query = "foo bar"
-    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
+    embedding = NVIDIAEmbeddings(model=embedding_model, **mode)
     output = await embedding.aembed_query(query)
-    assert len(output) == 1024
+    assert len(output) > 3
 
 
 def test_embed_documents_single(embedding_model: str, mode: dict) -> None:
     """Test NVIDIA embeddings for documents."""
     documents = ["foo bar"]
-    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
+    embedding = NVIDIAEmbeddings(model=embedding_model, **mode)
     output = embedding.embed_documents(documents)
     assert len(output) == 1
-    assert len(output[0]) == 1024  # Assuming embedding size is 2048
+    assert len(output[0]) > 3
 
 
 def test_embed_documents_multiple(embedding_model: str, mode: dict) -> None:
     """Test NVIDIA embeddings for multiple documents."""
     documents = ["foo bar", "bar foo", "foo"]
-    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
+    embedding = NVIDIAEmbeddings(model=embedding_model, **mode)
     output = embedding.embed_documents(documents)
     assert len(output) == 3
-    assert all(len(doc) == 1024 for doc in output)
+    assert all(len(doc) > 4 for doc in output)
 
 
 async def test_embed_documents_multiple_async(embedding_model: str, mode: dict) -> None:
     """Test NVIDIA async embeddings for multiple documents."""
     documents = ["foo bar", "bar foo", "foo"]
-    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
+    embedding = NVIDIAEmbeddings(model=embedding_model, **mode)
     output = await embedding.aembed_documents(documents)
     assert len(output) == 3
-    assert all(len(doc) == 1024 for doc in output)
+    assert all(len(doc) > 4 for doc in output)
 
 
 def test_embed_available_models(mode: dict) -> None:
@@ -77,25 +87,25 @@ def test_embed_available_models_cached() -> None:
 
 
 def test_embed_query_long_text(embedding_model: str, mode: dict) -> None:
-    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
+    embedding = NVIDIAEmbeddings(model=embedding_model, **mode)
     text = "nvidia " * 2048
     with pytest.raises(Exception):
         embedding.embed_query(text)
 
 
 def test_embed_documents_batched_texts(embedding_model: str, mode: dict) -> None:
-    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
+    embedding = NVIDIAEmbeddings(model=embedding_model, **mode)
     count = NVIDIAEmbeddings._default_max_batch_size * 2 + 1
     texts = ["nvidia " * 32] * count
     output = embedding.embed_documents(texts)
     assert len(output) == count
-    assert all(len(embedding) == 1024 for embedding in output)
+    assert all(len(embedding) > 3 for embedding in output)
 
 
 def test_embed_documents_mixed_long_texts(embedding_model: str, mode: dict) -> None:
     if embedding_model == "nvolveqa_40k":
         pytest.xfail("AI Foundation Model trucates by default")
-    embedding = NVIDIAEmbeddings(model=embedding_model).mode(**mode)
+    embedding = NVIDIAEmbeddings(model=embedding_model, **mode)
     count = NVIDIAEmbeddings._default_max_batch_size * 2 - 1
     texts = ["nvidia " * 32] * count
     texts[len(texts) // 2] = "nvidia " * 2048
@@ -107,17 +117,17 @@ def test_embed_documents_mixed_long_texts(embedding_model: str, mode: dict) -> N
 def test_embed_query_truncate(embedding_model: str, mode: dict, truncate: str) -> None:
     if embedding_model == "nvolveqa_40k":
         pytest.xfail("AI Foundation Model does not support truncate option")
-    embedding = NVIDIAEmbeddings(model=embedding_model, truncate=truncate).mode(**mode)
+    embedding = NVIDIAEmbeddings(model=embedding_model, truncate=truncate, **mode)
     text = "nvidia " * 2048
     output = embedding.embed_query(text)
-    assert len(output) == 1024
+    assert len(output) > 3
 
 
 @pytest.mark.parametrize("truncate", ["START", "END"])
 def test_embed_documents_truncate(
     embedding_model: str, mode: dict, truncate: str
 ) -> None:
-    embedding = NVIDIAEmbeddings(model=embedding_model, truncate=truncate).mode(**mode)
+    embedding = NVIDIAEmbeddings(model=embedding_model, truncate=truncate, **mode)
     count = 10
     texts = ["nvidia " * 32] * count
     texts[len(texts) // 2] = "nvidia " * 2048

--- a/libs/ai-endpoints/tests/integration_tests/test_other_models.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_other_models.py
@@ -10,7 +10,7 @@ from langchain_nvidia_ai_endpoints.chat_models import ChatNVIDIA
 
 def test_chat_ai_endpoints_context_message(qa_model: str, mode: dict) -> None:
     """Test wrapper with context message."""
-    chat = ChatNVIDIA(model=qa_model, max_tokens=36).mode(**mode)
+    chat = ChatNVIDIA(model=qa_model, max_tokens=36, **mode)
     context_message = BaseMessage(
         content="Once upon a time there was a little langchainer", type="context"
     )
@@ -22,7 +22,7 @@ def test_chat_ai_endpoints_context_message(qa_model: str, mode: dict) -> None:
 
 def test_image_in_models(image_in_model: str, mode: dict) -> None:
     try:
-        chat = ChatNVIDIA(model=image_in_model).mode(**mode)
+        chat = ChatNVIDIA(model=image_in_model, **mode)
         response = chat.invoke(
             [
                 HumanMessage(

--- a/libs/ai-endpoints/tests/unit_tests/test_chat_models.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_chat_models.py
@@ -55,3 +55,17 @@ def test_param_labels_deprecated() -> None:
         ChatNVIDIA()
     with pytest.deprecated_call():
         ChatNVIDIA(labels={"label": 1.0})
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "bogus",
+        "http:/",
+        "http://",
+        "http:/oops",
+    ],
+)
+def test_param_base_url_negative(base_url: str) -> None:
+    with pytest.raises(ValueError):
+        ChatNVIDIA(base_url=base_url)


### PR DESCRIPTION
# Description

To simplify and align switching from hosted and local backends, the `mode()` method is deprecated in favor of using `base_url` passed to constructors.

The `mode()` method will be removed in v0.1.

Old usage -
```
from langchain_nvidia_ai_endpoints import ChatNVIDIA, NVIDIAEmbeddings, NVIDIARerank

llm = ChatNVIDIA().mode("nim", base_url="http://localhost:8000/v1")
embedder = NVIDIAEmbeddings().mode("nim", base_url="http://localhost:12345/v1")
ranker = NVIDIARerank().mode("nim", base_url="http://localhost:1976/v1")
```

New usage -
```
from langchain_nvidia_ai_endpoints import ChatNVIDIA, NVIDIAEmbeddings, NVIDIARerank

llm = ChatNVIDIA(base_url="http://localhost:8000/v1")
embedder = NVIDIAEmbeddings(base_url="http://localhost:12345/v1")
ranker = NVIDIARerank(base_url="http://localhost:1976/v1")
```

A full documentation refresh will follow. I want to get the deprecation warnings to users ASAP.
