### PR TITLE
make connectors use user provided base_url when the provided model is also hosted

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -524,6 +524,11 @@ class _NVIDIAClient(BaseModel):
             name = values.get("model")
             if model := determine_model(name):
                 values["model"] = model.id
+                # not all models are on https://integrate.api.nvidia.com/v1,
+                # those that are not are served from their own endpoints
+                if model.endpoint:
+                    # we override the infer_path to use the custom endpoint
+                    values["client"].infer_path = model.endpoint
             else:
                 if not (client := values.get("client")):
                     warnings.warn(f"Unable to determine validity of {name}")

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -44,7 +44,7 @@ from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool
 
 from langchain_nvidia_ai_endpoints._common import _NVIDIAClient
-from langchain_nvidia_ai_endpoints._statics import Model, determine_model
+from langchain_nvidia_ai_endpoints._statics import Model
 
 _CallbackManager = Union[AsyncCallbackManagerForLLMRun, CallbackManagerForLLMRun]
 _DictOrPydanticClass = Union[Dict[str, Any], Type[BaseModel]]
@@ -168,17 +168,11 @@ class ChatNVIDIA(BaseChatModel):
             environment variable.
         """
         super().__init__(**kwargs)
-        infer_path = "{base_url}/chat/completions"
-        # not all chat models are on https://integrate.api.nvidia.com/v1,
-        # those that are not are served from their own endpoints
-        if model := determine_model(self.model):
-            if model.endpoint:  # some models have custom endpoints
-                infer_path = model.endpoint
         self._client = _NVIDIAClient(
             base_url=self.base_url,
             model=self.model,
             api_key=kwargs.get("nvidia_api_key", kwargs.get("api_key", None)),
-            infer_path=infer_path,
+            infer_path="{base_url}/chat/completions",
         )
         # todo: only store the model in one place
         # the model may be updated to a newer name during initialization

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
@@ -8,7 +8,7 @@ from langchain_core.outputs.llm_result import LLMResult
 from langchain_core.pydantic_v1 import BaseModel, Field, PrivateAttr, validator
 
 from langchain_nvidia_ai_endpoints._common import _NVIDIAClient
-from langchain_nvidia_ai_endpoints._statics import Model, determine_model
+from langchain_nvidia_ai_endpoints._statics import Model
 from langchain_nvidia_ai_endpoints.callbacks import usage_callback_var
 
 
@@ -69,17 +69,11 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
             environment variable.
         """
         super().__init__(**kwargs)
-        infer_path = "{base_url}/embeddings"
-        # not all embedding models are on https://integrate.api.nvidia.com/v1,
-        # those that are not are served from their own endpoints
-        if model := determine_model(self.model):
-            if model.endpoint:  # some models have custom endpoints
-                infer_path = model.endpoint
         self._client = _NVIDIAClient(
             base_url=self.base_url,
             model=self.model,
             api_key=kwargs.get("nvidia_api_key", kwargs.get("api_key", None)),
-            infer_path=infer_path,
+            infer_path="{base_url}/embeddings",
         )
         # todo: only store the model in one place
         # the model may be updated to a newer name during initialization

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
@@ -8,7 +8,7 @@ from langchain_core.documents.compressor import BaseDocumentCompressor
 from langchain_core.pydantic_v1 import BaseModel, Field, PrivateAttr
 
 from langchain_nvidia_ai_endpoints._common import _NVIDIAClient
-from langchain_nvidia_ai_endpoints._statics import Model, determine_model
+from langchain_nvidia_ai_endpoints._statics import Model
 
 
 class Ranking(BaseModel):
@@ -62,17 +62,11 @@ class NVIDIARerank(BaseDocumentCompressor):
             environment variable.
         """
         super().__init__(**kwargs)
-        infer_path = "{base_url}/ranking"
-        # not all models are on https://integrate.api.nvidia.com/v1,
-        # those that are not are served from their own endpoints
-        if model := determine_model(self.model):
-            if model.endpoint:  # some models have custom endpoints
-                infer_path = model.endpoint
         self._client = _NVIDIAClient(
             base_url=self.base_url,
             model=self.model,
             api_key=kwargs.get("nvidia_api_key", kwargs.get("api_key", None)),
-            infer_path=infer_path,
+            infer_path="{base_url}/ranking",
         )
         # todo: only store the model in one place
         # the model may be updated to a newer name during initialization


### PR DESCRIPTION
previously, if a model was known to be hosted on a custom endpoint and a user ran the same model locally, the connectors would favor the hosted version. for instance, NVIDIAEmbeddings(model="NV-Embed-QA", base_url="http://localhost/v1") would contact the hosted NV-Embed-QA. likewise, ChatNVIDIA(model="mistralai/mixtral-8x7b-instruct-v0.1", base_url="http://localhost/v1") would contact the hosted mistralai/mixtral-8x7b-instruct-v0.1.

fixes #31