### PR TITLE
Fix for NVIDIAClient output to redact the api_key

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -442,11 +442,17 @@ class NVEModel(BaseModel):
             payload = {**payload, "stream": True}
         self.last_inputs = {
             "url": invoke_url,
-            "headers": self.headers["stream"],
+            # "headers": self.headers["stream"],
             "json": self.payload_fn(payload),
             "stream": True,
         }
-        response = self.get_session_fn().post(**self.last_inputs)
+        headers = {
+            "Authorization": f"Bearer {self.api_key.get_secret_value()}"
+            if self.api_key
+            else None,
+            **self.headers["stream"],
+        }
+        response = self.get_session_fn().post(headers=headers, **self.last_inputs)
         self._try_raise(response)
         call = self.copy()
 
@@ -477,11 +483,17 @@ class NVEModel(BaseModel):
             payload = {**payload, "stream": True}
         self.last_inputs = {
             "url": invoke_url,
-            "headers": self.headers["stream"],
+            # "headers": self.headers["stream"],
             "json": self.payload_fn(payload),
         }
+        headers = {
+            "Authorization": f"Bearer {self.api_key.get_secret_value()}"
+            if self.api_key
+            else None,
+            **self.headers["stream"],
+        }
         async with self.get_asession_fn() as session:
-            async with session.post(**self.last_inputs) as response:
+            async with session.post(headers=headers, **self.last_inputs) as response:
                 self._try_raise(response)
                 async for line in response.content.iter_any():
                     if line and line.strip() != b"data: [DONE]":

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -143,7 +143,7 @@ class NVEModel(BaseModel):
         )
         return values
 
-    def _add_authorization(self) -> Dict:
+    def __add_authorization(self) -> Dict:
         return {
             "Authorization": f"Bearer {self.api_key.get_secret_value()}"
             if self.api_key
@@ -197,7 +197,7 @@ class NVEModel(BaseModel):
             "json": self.payload_fn(payload),
             "stream": False,
         }
-        headers = self._add_authorization()
+        headers = self.__add_authorization()
         headers.update(**self.headers["call"])
         session = self.get_session_fn()
         self.last_response = response = session.post(
@@ -219,7 +219,7 @@ class NVEModel(BaseModel):
         if payload:
             self.last_inputs["json"] = self.payload_fn(payload)
 
-        headers = self._add_authorization()
+        headers = self.__add_authorization()
         headers.update(**self.headers["call"])
         session = self.get_session_fn()
         self.last_response = response = session.get(headers=headers, **self.last_inputs)
@@ -444,7 +444,7 @@ class NVEModel(BaseModel):
             "stream": True,
         }
 
-        headers = self._add_authorization()
+        headers = self.__add_authorization()
         headers.update(**self.headers["stream"])
         response = self.get_session_fn().post(headers=headers, **self.last_inputs)
         self._try_raise(response)
@@ -480,7 +480,7 @@ class NVEModel(BaseModel):
             "json": self.payload_fn(payload),
         }
 
-        headers = self._add_authorization()
+        headers = self.__add_authorization()
         headers.update(**self.headers["stream"])
         async with self.get_asession_fn() as session:
             async with session.post(headers=headers, **self.last_inputs) as response:

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -143,6 +143,13 @@ class NVEModel(BaseModel):
         )
         return values
 
+    def _add_authorization(self) -> Dict:
+        return {
+            "Authorization": f"Bearer {self.api_key.get_secret_value()}"
+            if self.api_key
+            else None,
+        }
+
     @property
     def available_models(self) -> list[Model]:
         """List the available models that can be invoked."""
@@ -187,16 +194,11 @@ class NVEModel(BaseModel):
         """Method for posting to the AI Foundation Model Function API."""
         self.last_inputs = {
             "url": invoke_url,
-            # "headers": self.headers["call"],
             "json": self.payload_fn(payload),
             "stream": False,
         }
-        headers = {
-            "Authorization": f"Bearer {self.api_key.get_secret_value()}"
-            if self.api_key
-            else None,
-            **self.headers["call"],
-        }
+        headers = self._add_authorization()
+        headers.update(**self.headers["call"])
         session = self.get_session_fn()
         self.last_response = response = session.post(
             headers=headers, **self.last_inputs
@@ -212,17 +214,13 @@ class NVEModel(BaseModel):
         """Method for getting from the AI Foundation Model Function API."""
         self.last_inputs = {
             "url": invoke_url,
-            # "headers": self.headers["call"],
             "stream": False,
         }
         if payload:
             self.last_inputs["json"] = self.payload_fn(payload)
-        headers = {
-            "Authorization": f"Bearer {self.api_key.get_secret_value()}"
-            if self.api_key
-            else None,
-            **self.headers["call"],
-        }
+
+        headers = self._add_authorization()
+        headers.update(**self.headers["call"])
         session = self.get_session_fn()
         self.last_response = response = session.get(headers=headers, **self.last_inputs)
         self._try_raise(response)
@@ -442,16 +440,12 @@ class NVEModel(BaseModel):
             payload = {**payload, "stream": True}
         self.last_inputs = {
             "url": invoke_url,
-            # "headers": self.headers["stream"],
             "json": self.payload_fn(payload),
             "stream": True,
         }
-        headers = {
-            "Authorization": f"Bearer {self.api_key.get_secret_value()}"
-            if self.api_key
-            else None,
-            **self.headers["stream"],
-        }
+
+        headers = self._add_authorization()
+        headers.update(**self.headers["stream"])
         response = self.get_session_fn().post(headers=headers, **self.last_inputs)
         self._try_raise(response)
         call = self.copy()
@@ -483,15 +477,11 @@ class NVEModel(BaseModel):
             payload = {**payload, "stream": True}
         self.last_inputs = {
             "url": invoke_url,
-            # "headers": self.headers["stream"],
             "json": self.payload_fn(payload),
         }
-        headers = {
-            "Authorization": f"Bearer {self.api_key.get_secret_value()}"
-            if self.api_key
-            else None,
-            **self.headers["stream"],
-        }
+
+        headers = self._add_authorization()
+        headers.update(**self.headers["stream"])
         async with self.get_asession_fn() as session:
             async with session.post(headers=headers, **self.last_inputs) as response:
                 self._try_raise(response)

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -207,9 +207,10 @@ class NVEModel(BaseModel):
             "json": self.payload_fn(payload),
             "stream": False,
         }
-        payload = self.__add_authorization(deepcopy(self.last_inputs))
         session = self.get_session_fn()
-        self.last_response = response = session.post(**payload)
+        self.last_response = response = session.post(
+            **self.__add_authorization(deepcopy(self.last_inputs))
+        )
         self._try_raise(response)
         return response, session
 
@@ -227,9 +228,10 @@ class NVEModel(BaseModel):
         if payload:
             self.last_inputs["json"] = self.payload_fn(payload)
 
-        payload = self.__add_authorization(deepcopy(self.last_inputs))
         session = self.get_session_fn()
-        self.last_response = response = session.get(**payload)
+        self.last_response = response = session.get(
+            **self.__add_authorization(deepcopy(self.last_inputs))
+        )
         self._try_raise(response)
         return response, session
 
@@ -452,8 +454,9 @@ class NVEModel(BaseModel):
             "stream": True,
         }
 
-        payload = self.__add_authorization(deepcopy(self.last_inputs))
-        response = self.get_session_fn().post(**payload)
+        response = self.get_session_fn().post(
+            **self.__add_authorization(deepcopy(self.last_inputs))
+        )
         self._try_raise(response)
         call = self.copy()
 
@@ -488,9 +491,10 @@ class NVEModel(BaseModel):
             "json": self.payload_fn(payload),
         }
 
-        payload = self.__add_authorization(deepcopy(self.last_inputs))
         async with self.get_asession_fn() as session:
-            async with session.post(**payload) as response:
+            async with session.post(
+                **self.__add_authorization(deepcopy(self.last_inputs))
+            ) as response:
                 self._try_raise(response)
                 async for line in response.content.iter_any():
                     if line and line.strip() != b"data: [DONE]":

--- a/libs/ai-endpoints/tests/unit_tests/test_api_key.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_api_key.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from typing import Any, Generator
 
 import pytest
+from langchain_core.pydantic_v1 import SecretStr
 
 
 @contextmanager
@@ -43,3 +44,13 @@ def test_api_key_priority(public_class: type) -> None:
         assert get_api_key(public_class(nvidia_api_key="PARAM")) == "PARAM"
         assert get_api_key(public_class(api_key="PARAM")) == "PARAM"
         assert get_api_key(public_class(api_key="LOW", nvidia_api_key="HIGH")) == "HIGH"
+
+
+def test_api_key_type(public_class: type) -> None:
+    # Test case to make sure the api_key is SecretStr and not str
+    def get_api_key(instance: Any) -> str:
+        return instance._client.client.api_key
+
+    with no_env_var("NVIDIA_API_KEY"):
+        os.environ["NVIDIA_API_KEY"] = "ENV"
+        assert type(get_api_key(public_class())) == SecretStr


### PR DESCRIPTION
Fix for the client as the output includes the Bearer key, unredacted.