### PR TITLE
Provide default model in local NIM mode

### DIFF
--- a/libs/ai-endpoints/docs/chat/nvidia_ai_endpoints.ipynb
+++ b/libs/ai-endpoints/docs/chat/nvidia_ai_endpoints.ipynb
@@ -138,6 +138,28 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7d4a4e2e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ubuntu/raspawar/langchain-nvidia/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py:583: UserWarning: Default model is set as: meta/llama3-8b-instruct. \n",
+      "Set model using model parameter. \n",
+      "To get available models use available_models property.\n",
+      "  UserWarning,\n"
+     ]
+    }
+   ],
+   "source": [
+    "# OR connect to an embedding NIM running at localhost:8000, with default model(first available model)\n",
+    "llm = ChatNVIDIA(base_url=\"http://localhost:8000/v1\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "71d37987-d568-4a73-9d2a-8bd86323f8bf",
    "metadata": {},

--- a/libs/ai-endpoints/docs/text_embedding/nvidia_ai_endpoints.ipynb
+++ b/libs/ai-endpoints/docs/text_embedding/nvidia_ai_endpoints.ipynb
@@ -143,14 +143,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings\n",
     "\n",
     "# connect to an embedding NIM running at localhost:8080\n",
-    "embedder = NVIDIAEmbeddings(base_url=\"http://localhost:8080/v1\")"
+    "embedder = NVIDIAEmbeddings(base_url=\"http://localhost:9080/v1\", model=\"NV-Embed-QA\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ubuntu/raspawar/langchain-nvidia/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py:579: UserWarning: Default model is set as: NV-Embed-QA. \n",
+      "Set model using model parameter. \n",
+      "To get available models use available_models property.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "# connect to an default embedding NIM running at localhost:8080\n",
+    "embedder = NVIDIAEmbeddings(base_url=\"http://localhost:9080/v1\")"
    ]
   },
   {
@@ -521,7 +542,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -189,9 +189,6 @@ class NVEModel(BaseModel):
             # add base model for local-nim mode
             model.base_model = element.get("root")
 
-            if model.base_model and model.id != model.base_model:
-                model.model_type = "lora"
-
             self._available_models.append(model)
 
         return self._available_models
@@ -608,14 +605,13 @@ class _NVIDIAClient(BaseModel):
     ) -> List[Model]:
         """Retrieve a list of available models."""
 
-        # set client for lora models in local-nim mode
-        if not self.is_hosted:
-            for model in self.client.available_models:
-                if model.model_type == "lora":
-                    model.client = filter
-
         available = [
-            model for model in self.client.available_models if model.client == filter
+            model
+            for model in self.client.available_models
+            if (
+                model.client == filter
+                or (model.base_model and model.base_model != model.id)
+            )
         ]
 
         # if we're talking to a hosted endpoint, we mix in the known models

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -537,16 +537,6 @@ class _NVIDIAClient(BaseModel):
     @root_validator
     def _postprocess_args(cls, values: Any) -> Any:
         name = values.get("model")
-        if not name:
-            # set default model
-            name = values.get("client").default_model.id
-            values["model"] = name
-            warnings.warn(
-                f"Default model is set as: {name}. \n"
-                "Set model using model parameter. \n"
-                "To get available models use available_models property.",
-                UserWarning,
-            )
         if values["is_hosted"]:
             if not values["client"].api_key:
                 warnings.warn(
@@ -574,6 +564,18 @@ class _NVIDIAClient(BaseModel):
                         raise ValueError(
                             f"Model {name} is unknown, check `available_models`"
                         )
+        else:
+            if not name:
+                # set default model
+                name = values.get("client").default_model.id
+                values["model"] = name
+                warnings.warn(
+                    f"Default model is set as: {name}. \n"
+                    "Set model using model parameter. \n"
+                    "To get available models use available_models property.",
+                    UserWarning,
+                )
+                    
         return values
 
     @classmethod

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -20,6 +20,7 @@ class Model(BaseModel):
     client: Optional[str] = None
     endpoint: Optional[str] = None
     aliases: Optional[list] = None
+    base_model: Optional[str] = None
 
     def __hash__(self) -> int:
         return hash(self.id)

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -136,7 +136,7 @@ class ChatNVIDIA(BaseChatModel):
         "https://integrate.api.nvidia.com/v1",
         description="Base url for model listing an invocation",
     )
-    model: str = Field(_default_model, description="Name of the model to invoke")
+    model: Optional[str] = Field(..., description="Name of the model to invoke")
     temperature: Optional[float] = Field(description="Sampling temperature in [0, 1]")
     max_tokens: Optional[int] = Field(
         1024, description="Maximum # of tokens to generate"

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -136,7 +136,7 @@ class ChatNVIDIA(BaseChatModel):
         "https://integrate.api.nvidia.com/v1",
         description="Base url for model listing an invocation",
     )
-    model: Optional[str] = Field(..., description="Name of the model to invoke")
+    model: Optional[str] = Field(description="Name of the model to invoke")
     temperature: Optional[float] = Field(description="Sampling temperature in [0, 1]")
     max_tokens: Optional[int] = Field(
         1024, description="Maximum # of tokens to generate"

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -173,6 +173,7 @@ class ChatNVIDIA(BaseChatModel):
         self._client = _NVIDIAClient(
             base_url=self.base_url,
             model=self.model,
+            default_model=self._default_model,
             api_key=kwargs.get("nvidia_api_key", kwargs.get("api_key", None)),
             infer_path="{base_url}/chat/completions",
         )

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
@@ -33,7 +33,7 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
         "https://integrate.api.nvidia.com/v1",
         description="Base url for model listing an invocation",
     )
-    model: str = Field(_default_model, description="Name of the model to invoke")
+    model: Optional[str] = Field(description="Name of the model to invoke")
     truncate: Literal["NONE", "START", "END"] = Field(
         default="NONE",
         description=(
@@ -72,6 +72,7 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
         self._client = _NVIDIAClient(
             base_url=self.base_url,
             model=self.model,
+            default_model=self._default_model,
             api_key=kwargs.get("nvidia_api_key", kwargs.get("api_key", None)),
             infer_path="{base_url}/embeddings",
         )

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
@@ -35,9 +35,7 @@ class NVIDIARerank(BaseDocumentCompressor):
         description="Base url for model listing an invocation",
     )
     top_n: int = Field(5, ge=0, description="The number of documents to return.")
-    model: str = Field(
-        _default_model_name, description="The model to use for reranking."
-    )
+    model: Optional[str] = Field(description="The model to use for reranking.")
     max_batch_size: int = Field(
         _default_batch_size, ge=1, description="The maximum batch size."
     )
@@ -65,6 +63,7 @@ class NVIDIARerank(BaseDocumentCompressor):
         self._client = _NVIDIAClient(
             base_url=self.base_url,
             model=self.model,
+            default_model=self._default_model_name,
             api_key=kwargs.get("nvidia_api_key", kwargs.get("api_key", None)),
             infer_path="{base_url}/ranking",
         )

--- a/libs/ai-endpoints/tests/unit_tests/test_api_key.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_api_key.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from typing import Any, Generator
 
 import pytest
+import requests
 from langchain_core.pydantic_v1 import SecretStr
 
 
@@ -25,7 +26,8 @@ def test_create_without_api_key(public_class: type) -> None:
 
 def test_create_unknown_url_no_api_key(public_class: type) -> None:
     with no_env_var("NVIDIA_API_KEY"):
-        public_class(base_url="https://test_url/v1")
+        with pytest.raises(requests.exceptions.ConnectionError):
+            public_class(base_url="https://test_url/v1")
 
 
 @pytest.mark.parametrize("param", ["nvidia_api_key", "api_key"])

--- a/libs/ai-endpoints/tests/unit_tests/test_base_url.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_base_url.py
@@ -1,5 +1,5 @@
 import pytest
-import requests
+from requests_mock import Mocker
 
 
 @pytest.mark.parametrize(
@@ -25,6 +25,24 @@ def test_param_base_url_hosted(public_class: type, base_url: str) -> None:
     assert client._client.is_hosted
 
 
+@pytest.fixture(autouse=True)
+def mock_v1_local_models(requests_mock: Mocker, base_url: str) -> None:
+    requests_mock.get(
+        f"{base_url}/models",
+        json={
+            "data": [
+                {
+                    "id": "model1",
+                    "object": "model",
+                    "created": 1234567890,
+                    "owned_by": "OWNER",
+                    "root": "model1",
+                },
+            ]
+        },
+    )
+
+
 @pytest.mark.parametrize(
     "base_url",
     [
@@ -34,6 +52,5 @@ def test_param_base_url_hosted(public_class: type, base_url: str) -> None:
     ],
 )
 def test_param_base_url_not_hosted(public_class: type, base_url: str) -> None:
-    with pytest.raises(requests.exceptions.ConnectionError):
-        client = public_class(base_url=base_url)
-        assert not client._client.is_hosted
+    client = public_class(base_url=base_url)
+    assert not client._client.is_hosted

--- a/libs/ai-endpoints/tests/unit_tests/test_base_url.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_base_url.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 
 
 @pytest.mark.parametrize(
@@ -33,5 +34,6 @@ def test_param_base_url_hosted(public_class: type, base_url: str) -> None:
     ],
 )
 def test_param_base_url_not_hosted(public_class: type, base_url: str) -> None:
-    client = public_class(base_url=base_url)
-    assert not client._client.is_hosted
+    with pytest.raises(requests.exceptions.ConnectionError):
+        client = public_class(base_url=base_url)
+        assert not client._client.is_hosted

--- a/libs/ai-endpoints/tests/unit_tests/test_model.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_model.py
@@ -26,6 +26,31 @@ def mock_v1_models(requests_mock: Mocker, known_unknown: str) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def mock_v1_local_models(requests_mock: Mocker, known_unknown: str) -> None:
+    requests_mock.get(
+        "http://localhost:8000/v1/models",
+        json={
+            "data": [
+                {
+                    "id": known_unknown,
+                    "object": "model",
+                    "created": 1234567890,
+                    "owned_by": "OWNER",
+                    "root": known_unknown,
+                },
+                {
+                    "id": "lora1",
+                    "object": "model",
+                    "created": 1234567890,
+                    "owned_by": "OWNER",
+                    "root": known_unknown,
+                },
+            ]
+        },
+    )
+
+
 @pytest.mark.parametrize(
     "alias",
     [
@@ -84,3 +109,22 @@ def test_unknown_unknown(public_class: type) -> None:
     with pytest.raises(ValueError) as e:
         public_class(model="test/unknown-unknown", nvidia_api_key="a-bogus-key")
     assert "unknown" in str(e.value)
+
+
+def test_default_known(public_class: type, known_unknown: str) -> None:
+    """
+    Test that a model in the model table will be accepted.
+    """
+    # check if default model is getting set
+    with pytest.warns(UserWarning):
+        x = public_class(base_url="http://localhost:8000/v1")
+        assert x.model == known_unknown
+
+
+def test_default_lora(public_class: type) -> None:
+    """
+    Test that a model in the model table will be accepted.
+    """
+    # find a model that matches the public_class under test
+    x = public_class(base_url="http://localhost:8000/v1", model="lora1")
+    assert x.model == "lora1"


### PR DESCRIPTION
New implementation:

This can be simplified by using the first available model if none is provided, e.g.

llm = ChatNVIDIA(base_url="http://localhost:1234/v1")
llm.chat(...)

llm._client.model => default model => first available model in local NIM

Fixes:
- Display of the lora variants in local NIM mode
- _lint.yml workflow update for the failing lint checks