### PR TITLE
make stop property functional

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -318,7 +318,7 @@ class ChatNVIDIA(BaseChatModel):
         **kwargs: Any,
     ) -> dict:
         """Call to client generate method with call scope"""
-        kwargs["stop"] = kwargs.get("stop", self.stop)
+        kwargs["stop"] = kwargs.get("stop") or self.stop
         payload = self._get_payload(inputs=inputs, stream=False, **kwargs)
         out = self._client.client.get_req_generation(payload=payload)
         return out

--- a/libs/ai-endpoints/tests/integration_tests/test_chat_models.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_chat_models.py
@@ -202,9 +202,23 @@ def test_ai_endpoints_invoke(chat_model: str, mode: dict) -> None:
     assert isinstance(result.content, str)
 
 
-# todo: tests for parameters -
-#        bad: str - Bad words to avoid (cased)
-#        stop: str - Stop words (cased)
+# todo: test that stop is cased and works with multiple words
+def test_invoke_stop(chat_model: str, mode: dict) -> None:
+    """Test invoke's stop words."""
+    llm = ChatNVIDIA(model=chat_model, **mode, stop=["10"])
+    result = llm.invoke("please count to 20 by 1s, e.g. 1 2 3 4")
+    assert isinstance(result.content, str)
+    assert "10" not in result.content
+
+
+def test_stream_stop(chat_model: str, mode: dict) -> None:
+    """Test stream's stop words."""
+    llm = ChatNVIDIA(model=chat_model, **mode, stop=["10"])
+    result = ""
+    for token in llm.stream("please count to 20 by 1s, e.g. 1 2 3 4"):
+        assert isinstance(token.content, str)
+        result += f"{token.content}|"
+    assert "10" not in result
 
 
 # todo: max_tokens test for ainvoke, batch, abatch, stream, astream

--- a/libs/ai-endpoints/tests/unit_tests/test_stop.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_stop.py
@@ -1,0 +1,124 @@
+import pytest
+from requests_mock import Mocker
+
+from langchain_nvidia_ai_endpoints import ChatNVIDIA
+
+
+@pytest.fixture(autouse=True)
+def mock_v1_models(requests_mock: Mocker) -> None:
+    requests_mock.get(
+        "https://integrate.api.nvidia.com/v1/models",
+        json={
+            "data": [
+                {
+                    "id": "mock-model",
+                    "object": "model",
+                    "created": 1234567890,
+                    "owned_by": "OWNER",
+                }
+            ]
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_v1_chat_completions(requests_mock: Mocker) -> None:
+    requests_mock.post(
+        "https://integrate.api.nvidia.com/v1/chat/completions",
+        json={
+            "id": "mock-id",
+            "created": 1234567890,
+            "object": "chat.completion",
+            "model": "mock-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Ok"},
+                }
+            ],
+        },
+    )
+
+
+def test_stop_property_invoke(requests_mock: Mocker) -> None:
+    expected_stop = ["STOP"]
+
+    client = ChatNVIDIA(model="mock-model", api_key="mocked", stop=expected_stop)
+    response = client.invoke("Ok?")
+
+    assert response.content == "Ok"
+
+    assert requests_mock.last_request is not None
+    request_payload = requests_mock.last_request.json()
+    assert "stop" in request_payload
+    assert request_payload["stop"] == expected_stop
+
+
+def test_stop_parameter_invoke(requests_mock: Mocker) -> None:
+    expected_stop = ["STOP"]
+
+    client = ChatNVIDIA(model="mock-model", api_key="mocked")
+    response = client.invoke("Ok?", stop=expected_stop)
+
+    assert response.content == "Ok"
+
+    assert requests_mock.last_request is not None
+    request_payload = requests_mock.last_request.json()
+    assert "stop" in request_payload
+    assert request_payload["stop"] == expected_stop
+
+
+def test_stop_override_invoke(requests_mock: Mocker) -> None:
+    expected_stop = ["STOP"]
+
+    client = ChatNVIDIA(model="mock-model", api_key="mocked", stop=["GO"])
+    response = client.invoke("Ok?", stop=expected_stop)
+
+    assert response.content == "Ok"
+
+    assert requests_mock.last_request is not None
+    request_payload = requests_mock.last_request.json()
+    assert "stop" in request_payload
+    assert request_payload["stop"] == expected_stop
+
+
+def test_stop_property_stream(requests_mock: Mocker) -> None:
+    expected_stop = ["STOP"]
+
+    client = ChatNVIDIA(model="mock-model", api_key="mocked", stop=expected_stop)
+    response = client.stream("Ok?")
+
+    assert next(response).content == "Ok"
+
+    assert requests_mock.last_request is not None
+    request_payload = requests_mock.last_request.json()
+    assert "stop" in request_payload
+    assert request_payload["stop"] == expected_stop
+
+
+def test_stop_parameter_stream(requests_mock: Mocker) -> None:
+    expected_stop = ["STOP"]
+
+    client = ChatNVIDIA(model="mock-model", api_key="mocked")
+    response = client.stream("Ok?", stop=expected_stop)
+
+    assert next(response).content == "Ok"
+
+    assert requests_mock.last_request is not None
+    request_payload = requests_mock.last_request.json()
+    assert "stop" in request_payload
+    assert request_payload["stop"] == expected_stop
+
+
+def test_stop_override_stream(requests_mock: Mocker) -> None:
+    expected_stop = ["STOP"]
+
+    client = ChatNVIDIA(model="mock-model", api_key="mocked", stop=["GO"])
+    response = client.stream("Ok?", stop=expected_stop)
+
+    assert next(response).content == "Ok"
+
+    assert requests_mock.last_request is not None
+    request_payload = requests_mock.last_request.json()
+    assert "stop" in request_payload
+    assert request_payload["stop"] == expected_stop


### PR DESCRIPTION
`ChatNVIDIA(..., stop=...)` would not change the `stop` words for `invoke`

fixed `_generate` logic and added tests for `stop` across `invoke` and `stream`

future - we should deprecate the `stop` property on `ChatNVIDIA`