### PR TITLE
add register_model for users to add their own custom models with endpoints [api change; expansion]

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/__init__.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/__init__.py
@@ -39,8 +39,9 @@ embedding_output = embed_model.embed_query("Exploring AI capabilities.")
 ```
 """  # noqa: E501
 
+from langchain_nvidia_ai_endpoints._statics import Model, register_model
 from langchain_nvidia_ai_endpoints.chat_models import ChatNVIDIA
 from langchain_nvidia_ai_endpoints.embeddings import NVIDIAEmbeddings
 from langchain_nvidia_ai_endpoints.reranking import NVIDIARerank
 
-__all__ = ["ChatNVIDIA", "NVIDIAEmbeddings", "NVIDIARerank"]
+__all__ = ["ChatNVIDIA", "NVIDIAEmbeddings", "NVIDIARerank", "register_model", "Model"]

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -20,7 +20,7 @@ class Model(BaseModel):
     id: str
     # why do we have a model_type? because ChatNVIDIA can speak both chat and vlm.
     model_type: Optional[
-        Literal["chat", "vlm", "embedding", "ranking", "completion"]
+        Literal["chat", "vlm", "embedding", "ranking", "completion", "qa"]
     ] = None
     client: Optional[Literal["ChatNVIDIA", "NVIDIAEmbeddings", "NVIDIARerank"]] = None
     endpoint: Optional[str] = None
@@ -34,7 +34,7 @@ class Model(BaseModel):
     def validate_client(cls, client: str, values: dict) -> str:
         if client:
             supported = {
-                "ChatNVIDIA": ("chat", "vlm"),
+                "ChatNVIDIA": ("chat", "vlm", "qa"),
                 "NVIDIAEmbeddings": ("embedding",),
                 "NVIDIARerank": ("ranking",),
             }

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -418,11 +418,17 @@ def register_model(model: Model) -> None:
     Be sure that the `id` matches the model parameter the endpoint expects.
 
     Supported model types are:
-        - chat models must accept and produce chat completion payloads
+        - chat models, which must accept and produce chat completion payloads
     Supported model clients are:
-        - ChatNVIDIA for chat models
+        - ChatNVIDIA, for chat models
 
     Endpoint is required.
+
+    Use this instead of passing `base_url` to a client constructor
+    when the model's endpoint supports inference and not /v1/models
+    listing. Use `base_url` when the model's endpoint supports
+    /v1/models listing and inference on a known path,
+    e.g. /v1/chat/completions.
     """
     if model.id in MODEL_TABLE:
         warnings.warn(

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -1,29 +1,49 @@
 import warnings
-from typing import Optional
+from typing import Literal, Optional
 
-from langchain_core.pydantic_v1 import BaseModel
+from langchain_core.pydantic_v1 import BaseModel, validator
 
 
-#
-# Model information
-#  - id: unique identifier for the model, passed as model parameter for requests
-#  - model_type: API type (chat, vlm, embedding, ranking, completion)
-#  - client: client name
-#  - endpoint: custom endpoint for the model
-#  - aliases: list of aliases for the model
-#
-# All aliases are deprecated and will trigger a warning when used.
-#
 class Model(BaseModel):
+    """
+    Model information.
+
+    id: unique identifier for the model, passed as model parameter for requests
+    model_type: API type (chat, vlm, embedding, ranking, completion)
+    client: client name, e.g. ChatNVIDIA, NVIDIAEmbeddings, NVIDIARerank
+    endpoint: custom endpoint for the model
+    aliases: list of aliases for the model
+
+    All aliases are deprecated and will trigger a warning when used.
+    """
+
     id: str
-    model_type: Optional[str] = None
-    client: Optional[str] = None
+    # why do we have a model_type? because ChatNVIDIA can speak both chat and vlm.
+    model_type: Optional[
+        Literal["chat", "vlm", "embedding", "ranking", "completion"]
+    ] = None
+    client: Optional[Literal["ChatNVIDIA", "NVIDIAEmbeddings", "NVIDIARerank"]] = None
     endpoint: Optional[str] = None
     aliases: Optional[list] = None
     base_model: Optional[str] = None
 
     def __hash__(self) -> int:
         return hash(self.id)
+
+    @validator("client", always=True)
+    def validate_client(cls, client: str, values: dict) -> str:
+        if client:
+            supported = {
+                "ChatNVIDIA": ("chat", "vlm"),
+                "NVIDIAEmbeddings": ("embedding",),
+                "NVIDIARerank": ("ranking",),
+            }
+            model_type = values.get("model_type")
+            if model_type not in supported[client]:
+                raise ValueError(
+                    f"Model type '{model_type}' not supported by client '{client}'"
+                )
+        return client
 
 
 CHAT_MODEL_TABLE = {
@@ -361,14 +381,14 @@ RANKING_MODEL_TABLE = {
     ),
 }
 
-COMPLETION_MODEL_TABLE = {
-    "mistralai/mixtral-8x22b-v0.1": Model(
-        id="mistralai/mixtral-8x22b-v0.1",
-        model_type="completion",
-        client="NVIDIA",
-        aliases=["ai-mixtral-8x22b"],
-    ),
-}
+# COMPLETION_MODEL_TABLE = {
+#     "mistralai/mixtral-8x22b-v0.1": Model(
+#         id="mistralai/mixtral-8x22b-v0.1",
+#         model_type="completion",
+#         client="NVIDIA",
+#         aliases=["ai-mixtral-8x22b"],
+#     ),
+# }
 
 MODEL_TABLE = {
     **CHAT_MODEL_TABLE,
@@ -377,6 +397,42 @@ MODEL_TABLE = {
     **EMBEDDING_MODEL_TABLE,
     **RANKING_MODEL_TABLE,
 }
+
+
+def register_model(model: Model) -> None:
+    """
+    Register a model as a known model. This must be done at the
+    beginning of a program, at least before the model is used or
+    available models are listed.
+
+    For instance -
+    ```
+    from langchain_nvidia_ai_endpoints import register_model, Model
+    register_model(Model(id="my-custom-model-name",
+                         model_type="chat",
+                         client="ChatNVIDIA",
+                         endpoint="http://host:port/path-to-my-model"))
+    llm = ChatNVIDIA(model="my-custom-model-name")
+    ```
+
+    Be sure that the `id` matches the model parameter the endpoint expects.
+
+    Supported model types are:
+        - chat models must accept and produce chat completion payloads
+    Supported model clients are:
+        - ChatNVIDIA for chat models
+
+    Endpoint is required.
+    """
+    if model.id in MODEL_TABLE:
+        warnings.warn(
+            f"Model {model.id} is already registered. "
+            f"Overriding {MODEL_TABLE[model.id]}",
+            UserWarning,
+        )
+    if not model.endpoint:
+        raise ValueError(f"Model {model.id} does not have an endpoint.")
+    MODEL_TABLE[model.id] = model
 
 
 def lookup_model(name: str) -> Optional[Model]:

--- a/libs/ai-endpoints/tests/integration_tests/conftest.py
+++ b/libs/ai-endpoints/tests/integration_tests/conftest.py
@@ -1,9 +1,8 @@
-import inspect
-from typing import List
+from typing import Any, List
 
 import pytest
+from langchain_core.documents import Document
 
-import langchain_nvidia_ai_endpoints
 from langchain_nvidia_ai_endpoints import ChatNVIDIA, NVIDIAEmbeddings, NVIDIARerank
 from langchain_nvidia_ai_endpoints._statics import MODEL_TABLE, Model
 
@@ -129,9 +128,25 @@ def mode(request: pytest.FixtureRequest) -> dict:
 
 @pytest.fixture(
     params=[
-        member[1]
-        for member in inspect.getmembers(langchain_nvidia_ai_endpoints, inspect.isclass)
+        ChatNVIDIA,
+        NVIDIAEmbeddings,
+        NVIDIARerank,
     ]
 )
 def public_class(request: pytest.FixtureRequest) -> type:
     return request.param
+
+
+@pytest.fixture
+def contact_service() -> Any:
+    def _contact_service(instance: Any) -> None:
+        if isinstance(instance, ChatNVIDIA):
+            instance.invoke("Hello")
+        elif isinstance(instance, NVIDIAEmbeddings):
+            instance.embed_documents(["Hello"])
+        elif isinstance(instance, NVIDIARerank):
+            instance.compress_documents(
+                documents=[Document(page_content="World")], query="Hello"
+            )
+
+    return _contact_service

--- a/libs/ai-endpoints/tests/integration_tests/test_api_key.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_api_key.py
@@ -2,26 +2,14 @@ import os
 from typing import Any
 
 import pytest
-from langchain_core.documents import Document
 from langchain_core.messages import HumanMessage
 
-from langchain_nvidia_ai_endpoints import ChatNVIDIA, NVIDIAEmbeddings, NVIDIARerank
+from langchain_nvidia_ai_endpoints import ChatNVIDIA
 
 from ..unit_tests.test_api_key import no_env_var
 
 
-def contact_service(instance: Any) -> None:
-    if isinstance(instance, ChatNVIDIA):
-        instance.invoke("Hello")
-    elif isinstance(instance, NVIDIAEmbeddings):
-        instance.embed_documents(["Hello"])
-    elif isinstance(instance, NVIDIARerank):
-        instance.compress_documents(
-            documents=[Document(page_content="World")], query="Hello"
-        )
-
-
-def test_missing_api_key_error(public_class: type) -> None:
+def test_missing_api_key_error(public_class: type, contact_service: Any) -> None:
     with no_env_var("NVIDIA_API_KEY"):
         with pytest.warns(UserWarning):
             client = public_class()
@@ -33,7 +21,7 @@ def test_missing_api_key_error(public_class: type) -> None:
         assert "API key" in message
 
 
-def test_bogus_api_key_error(public_class: type) -> None:
+def test_bogus_api_key_error(public_class: type, contact_service: Any) -> None:
     with no_env_var("NVIDIA_API_KEY"):
         client = public_class(nvidia_api_key="BOGUS")
         with pytest.raises(Exception) as exc_info:
@@ -45,7 +33,7 @@ def test_bogus_api_key_error(public_class: type) -> None:
 
 
 @pytest.mark.parametrize("param", ["nvidia_api_key", "api_key"])
-def test_api_key(public_class: type, param: str) -> None:
+def test_api_key(public_class: type, param: str, contact_service: Any) -> None:
     api_key = os.environ.get("NVIDIA_API_KEY")
     with no_env_var("NVIDIA_API_KEY"):
         client = public_class(**{param: api_key})

--- a/libs/ai-endpoints/tests/integration_tests/test_base_url.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_base_url.py
@@ -1,7 +1,7 @@
+from typing import Any
+
 import pytest
 from requests.exceptions import ConnectionError
-
-from .test_api_key import contact_service
 
 
 @pytest.mark.parametrize(
@@ -13,6 +13,7 @@ from .test_api_key import contact_service
 def test_endpoint_unavailable(
     public_class: type,
     base_url: str,
+    contact_service: Any,
 ) -> None:
     # we test this with a bogus model because users should supply
     # a model when using their own base_url

--- a/libs/ai-endpoints/tests/integration_tests/test_register_model.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_register_model.py
@@ -1,0 +1,103 @@
+from typing import Any
+
+import pytest
+
+from langchain_nvidia_ai_endpoints import (
+    ChatNVIDIA,
+    Model,
+    NVIDIAEmbeddings,
+    NVIDIARerank,
+    register_model,
+)
+
+
+#
+# if this test is failing it may be because the function uuids have changed.
+# you will have to find the new ones from https://api.nvcf.nvidia.com/v2/nvcf/functions
+#
+@pytest.mark.parametrize(
+    "client, id, endpoint",
+    [
+        (
+            ChatNVIDIA,
+            "meta/llama3-8b-instruct",
+            "https://api.nvcf.nvidia.com/v2/nvcf/pexec/functions/a5a3ad64-ec2c-4bfc-8ef7-5636f26630fe",
+        ),
+        (
+            NVIDIAEmbeddings,
+            "NV-Embed-QA",
+            "https://api.nvcf.nvidia.com/v2/nvcf/pexec/functions/09c64e32-2b65-4892-a285-2f585408d118",
+        ),
+        (
+            NVIDIARerank,
+            "nv-rerank-qa-mistral-4b:1",
+            "https://api.nvcf.nvidia.com/v2/nvcf/pexec/functions/0bf77f50-5c35-4488-8e7a-f49bb1974af6",
+        ),
+    ],
+)
+def test_registered_model_functional(
+    client: type, id: str, endpoint: str, contact_service: Any
+) -> None:
+    model = Model(id=id, endpoint=endpoint)
+    with pytest.warns(
+        UserWarning
+    ) as record:  # warns because we're overriding known models
+        register_model(model)
+        contact_service(client(model=id))
+    assert len(record) == 1
+    assert isinstance(record[0].message, UserWarning)
+    assert "already registered" in str(record[0].message)
+    assert "Overriding" in str(record[0].message)
+
+
+def test_registered_model_is_available() -> None:
+    register_model(
+        Model(
+            id="test/chat",
+            model_type="chat",
+            client="ChatNVIDIA",
+            endpoint="BOGUS",
+        )
+    )
+    register_model(
+        Model(
+            id="test/embedding",
+            model_type="embedding",
+            client="NVIDIAEmbeddings",
+            endpoint="BOGUS",
+        )
+    )
+    register_model(
+        Model(
+            id="test/rerank",
+            model_type="ranking",
+            client="NVIDIARerank",
+            endpoint="BOGUS",
+        )
+    )
+    chat_models = ChatNVIDIA.get_available_models()
+    embedding_models = NVIDIAEmbeddings.get_available_models()
+    ranking_models = NVIDIARerank.get_available_models()
+
+    assert "test/chat" in [model.id for model in chat_models]
+    assert "test/chat" not in [model.id for model in embedding_models]
+    assert "test/chat" not in [model.id for model in ranking_models]
+
+    assert "test/embedding" not in [model.id for model in chat_models]
+    assert "test/embedding" in [model.id for model in embedding_models]
+    assert "test/embedding" not in [model.id for model in ranking_models]
+
+    assert "test/rerank" not in [model.id for model in chat_models]
+    assert "test/rerank" not in [model.id for model in embedding_models]
+    assert "test/rerank" in [model.id for model in ranking_models]
+
+
+def test_registered_model_without_client_is_not_listed() -> None:
+    register_model(Model(id="test/no_client", endpoint="BOGUS"))
+    chat_models = ChatNVIDIA.get_available_models()
+    embedding_models = NVIDIAEmbeddings.get_available_models()
+    ranking_models = NVIDIARerank.get_available_models()
+
+    assert "test/no_client" not in [model.id for model in chat_models]
+    assert "test/no_client" not in [model.id for model in embedding_models]
+    assert "test/no_client" not in [model.id for model in ranking_models]

--- a/libs/ai-endpoints/tests/unit_tests/conftest.py
+++ b/libs/ai-endpoints/tests/unit_tests/conftest.py
@@ -1,14 +1,13 @@
-import inspect
-
 import pytest
 
-import langchain_nvidia_ai_endpoints
+from langchain_nvidia_ai_endpoints import ChatNVIDIA, NVIDIAEmbeddings, NVIDIARerank
 
 
 @pytest.fixture(
     params=[
-        member[1]
-        for member in inspect.getmembers(langchain_nvidia_ai_endpoints, inspect.isclass)
+        ChatNVIDIA,
+        NVIDIAEmbeddings,
+        NVIDIARerank,
     ]
 )
 def public_class(request: pytest.FixtureRequest) -> type:

--- a/libs/ai-endpoints/tests/unit_tests/test_imports.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_imports.py
@@ -1,6 +1,12 @@
 from langchain_nvidia_ai_endpoints import __all__
 
-EXPECTED_ALL = ["ChatNVIDIA", "NVIDIAEmbeddings", "NVIDIARerank"]
+EXPECTED_ALL = [
+    "ChatNVIDIA",
+    "NVIDIAEmbeddings",
+    "NVIDIARerank",
+    "register_model",
+    "Model",
+]
 
 
 def test_all_imports() -> None:

--- a/libs/ai-endpoints/tests/unit_tests/test_register_model.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_register_model.py
@@ -1,0 +1,79 @@
+import warnings
+
+import pytest
+
+from langchain_nvidia_ai_endpoints import Model, register_model
+
+
+@pytest.mark.parametrize(
+    "model_type, client",
+    [
+        ("chat", "NVIDIAEmbeddings"),
+        ("chat", "NVIDIARerank"),
+        ("vlm", "NVIDIAEmbeddings"),
+        ("vlm", "NVIDIARerank"),
+        ("embeddings", "ChatNVIDIA"),
+        ("embeddings", "NVIDIARerank"),
+        ("ranking", "ChatNVIDIA"),
+        ("ranking", "NVIDIAEmbeddings"),
+    ],
+)
+def test_mismatched_type_client(model_type: str, client: str) -> None:
+    with pytest.raises(ValueError) as e:
+        register_model(
+            Model(
+                id=f"{model_type}-{client}",
+                model_type=model_type,
+                client=client,
+                endpoint="BOGUS",
+            )
+        )
+    assert "not supported" in str(e.value)
+
+
+def test_duplicate_model_warns() -> None:
+    model = Model(id="registered-model", endpoint="BOGUS")
+    register_model(model)
+    with pytest.warns(UserWarning) as record:
+        register_model(model)
+    assert len(record) == 1
+    assert isinstance(record[0].message, UserWarning)
+    assert "already registered" in str(record[0].message)
+    assert "Overriding" in str(record[0].message)
+
+
+def test_registered_model_usable(public_class: type) -> None:
+    model_type = {
+        "ChatNVIDIA": "chat",
+        "NVIDIAEmbeddings": "embedding",
+        "NVIDIARerank": "ranking",
+    }[public_class.__name__]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        id = f"registered-model-{model_type}"
+        model = Model(
+            id=id,
+            model_type=model_type,
+            client=public_class.__name__,
+            endpoint="BOGUS",
+        )
+        register_model(model)
+        x = public_class(model=id, nvidia_api_key="a-bogus-key")
+        assert x.model == id
+
+
+def test_registered_model_without_client_usable(public_class: type) -> None:
+    id = f"test/no-client-{public_class.__name__}"
+    model = Model(id=id, endpoint="BOGUS")
+    register_model(model)
+    # todo: this should warn that the model is known but type is not
+    #       and therefore inference may not work
+    public_class(model=id, nvidia_api_key="a-bogus-key")
+
+
+def test_missing_endpoint() -> None:
+    with pytest.raises(ValueError) as e:
+        register_model(
+            Model(id="missing-endpoint", model_type="chat", client="ChatNVIDIA")
+        )
+    assert "does not have an endpoint" in str(e.value)


### PR DESCRIPTION
this expands the public api with a `Model` class and `register_model` function.

background: we currently support hosted (base_url of integration.api.nvidia.com/v1) as well as local NIMs (base_url controlled by user, e.g. localhost:1234/v1) using the `base_url` feature. the base_url must provide paths for model listing,  `/models`, and inference, one of  `/chat/completion`, `/embeddings` or `/ranking`.

use case:  users would like to support endpoints that only support inference (do not support model listing) and to minimize code changes when model names stay the same and endpoints change.

design -
```
from langchain_nvidia_ai_endpoints import register_model, Model, ChatNVIDIA
register_model(Model(id="my-custom-model-name", model_type="chat", client="ChatNVIDIA", endpoint="http://host:port/path-to-my-model"))
llm = ChatNVIDIA(model="my-custom-model-name")
```

rejected design -
```
from langchain_nvidia_ai_endpoints import ChatNVIDIA
llm = ChatNVIDIA(model="my-custom-model-name", endpoint="http://host:port/path-to-my-model")
```
reason for rejection: endpoints will change over time resulting in multiple refactoring points in user code. accepted design allows users to centrally add a model and then refer to it throughout their code is simpler.