### PR TITLE
remove broken stop word detection, rely on server side implementation

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -362,7 +362,6 @@ class NVEModel(BaseModel):
         """
         msg_list = self._process_response(response)
         msg, is_stopped = self._aggregate_msgs(msg_list)
-        msg, is_stopped = self._early_stop_msg(msg, is_stopped, stop=stop)
         return msg, is_stopped
 
     def _aggregate_msgs(self, msg_list: Sequence[dict]) -> Tuple[dict, bool]:
@@ -395,18 +394,6 @@ class NVEModel(BaseModel):
         if usage_holder:
             content_holder.update(token_usage=usage_holder)  ####
         return content_holder, is_stopped
-
-    def _early_stop_msg(
-        self, msg: dict, is_stopped: bool, stop: Optional[Sequence[str]] = None
-    ) -> Tuple[dict, bool]:
-        """Try to early-terminate streaming or generation by iterating over stop list"""
-        content = msg.get("content", "")
-        if content and stop:
-            for stop_str in stop:
-                if stop_str and stop_str in content:
-                    msg["content"] = content[: content.find(stop_str) + 1]
-                    is_stopped = True
-        return msg, is_stopped
 
     ####################################################################################
     ## Streaming interface to allow you to iterate through progressive generations

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -355,14 +355,13 @@ class NVEModel(BaseModel):
         return self._wait(response, session)
 
     def postprocess(
-        self, response: Union[str, Response], stop: Optional[Sequence[str]] = None
+        self,
+        response: Union[str, Response],
     ) -> Tuple[dict, bool]:
         """Parses a response from the AI Foundation Model Function API.
         Strongly assumes that the API will return a single response.
         """
-        msg_list = self._process_response(response)
-        msg, is_stopped = self._aggregate_msgs(msg_list)
-        return msg, is_stopped
+        return self._aggregate_msgs(self._process_response(response))
 
     def _aggregate_msgs(self, msg_list: Sequence[dict]) -> Tuple[dict, bool]:
         """Dig out relevant details of aggregated message"""
@@ -402,7 +401,6 @@ class NVEModel(BaseModel):
         self,
         payload: dict = {},
         invoke_url: Optional[str] = None,
-        stop: Optional[Sequence[str]] = None,
     ) -> Iterator:
         invoke_url = self._get_invoke_url(invoke_url)
         if payload.get("stream", True) is False:
@@ -425,7 +423,7 @@ class NVEModel(BaseModel):
             for line in response.iter_lines():
                 if line and line.strip() != b"data: [DONE]":
                     line = line.decode("utf-8")
-                    msg, final_line = call.postprocess(line, stop=stop)
+                    msg, final_line = call.postprocess(line)
                     yield msg
                     if final_line:
                         break

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -212,7 +212,7 @@ class ChatNVIDIA(BaseChatModel):
         inputs = self._custom_preprocess(messages)
         payload = self._get_payload(inputs=inputs, stop=stop, stream=False, **kwargs)
         response = self._client.client.get_req(payload=payload)
-        responses, _ = self._client.client.postprocess(response, stop=stop)
+        responses, _ = self._client.client.postprocess(response)
         self._set_callback_out(responses, run_manager)
         message = ChatMessage(**self._custom_postprocess(responses))
         generation = ChatGeneration(message=message)


### PR DESCRIPTION
remove the client side stop word detection and rely on server side implementation

two issues with client side implementation -

1. it was not being called in the v0.1 series (last worked in v0.0.20), effectively didn't work
2. it would return part of the stop word (`find(...) + 1`)

this simplifies the output post-processing, which moves us toward using standard post-processing tools.