### PR TITLE
Enable base_url to read from env variables

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -38,7 +38,7 @@ from langchain_core.outputs import (
     ChatGenerationChunk,
     ChatResult,
 )
-from langchain_core.pydantic_v1 import BaseModel, Field, PrivateAttr
+from langchain_core.pydantic_v1 import BaseModel, Field, PrivateAttr, root_validator
 from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool
 
@@ -131,8 +131,8 @@ class ChatNVIDIA(BaseChatModel):
 
     _client: _NVIDIAClient = PrivateAttr(_NVIDIAClient)
     _default_model: str = "mistralai/mixtral-8x7b-instruct-v0.1"
+    _default_base_url: str = "https://integrate.api.nvidia.com/v1"
     base_url: str = Field(
-        "https://integrate.api.nvidia.com/v1",
         description="Base url for model listing an invocation",
     )
     model: Optional[str] = Field(description="Name of the model to invoke")
@@ -143,6 +143,17 @@ class ChatNVIDIA(BaseChatModel):
     top_p: Optional[float] = Field(description="Top-p for distribution sampling")
     seed: Optional[int] = Field(description="The seed for deterministic results")
     stop: Optional[Sequence[str]] = Field(description="Stop words (cased)")
+
+    _base_url_var = "NVIDIA_BASE_URL"
+    @root_validator(pre=True)
+    def _validate_base_url(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        values["base_url"] = (
+            values.get(cls._base_url_var.lower())
+            or values.get("base_url")
+            or os.getenv(cls._base_url_var)
+            or cls._default_base_url
+        )
+        return values
 
     def __init__(self, **kwargs: Any):
         """


### PR DESCRIPTION
Add root_validator in class ChatNVIDIA to enable base_url read from the env variable
The logic order the validation
1, check `nvidia_base_url` argument in ChatNVIDIA class 
2, check `base_url` argument in ChatNVIDIA class 
3, check `NVIDIA_BASE_URL` environment variable 
4, use the default value defined in `_default_base_url` 