### PR TITLE
Scheduled test cases fix

### DIFF
--- a/libs/ai-endpoints/tests/integration_tests/test_chat_models.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_chat_models.py
@@ -125,6 +125,12 @@ def test_messages(
 ) -> None:
     if not system and not exchange:
         pytest.skip("No messages to test")
+    if (
+        chat_model == "mistralai/mixtral-8x7b-instruct-v0.1"
+        and exchange
+        and isinstance(exchange[0], AIMessage)
+    ):
+        pytest.skip("mistralai does not support system=>AIMessage")
     chat = ChatNVIDIA(model=chat_model, max_tokens=36, **mode)
     response = chat.invoke(system + exchange)
     assert isinstance(response, BaseMessage)


### PR DESCRIPTION
Fix for the scheduled integration test_chat_model test case failure

<img width="1260" alt="Screenshot 2024-07-12 at 7 42 32 PM" src="https://github.com/user-attachments/assets/1f04822d-305f-4fe5-8784-9867fa2e5080">

Reason for failure: mistralai model does not allow AIMessage followed by SystemMessage

[Successful Workflow](https://github.com/langchain-ai/langchain-nvidia/actions/runs/9909210226)