### PR TITLE
update default chat model to meta/llama3-8b-instruct (most features & deployment options)

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -130,7 +130,7 @@ class ChatNVIDIA(BaseChatModel):
     """
 
     _client: _NVIDIAClient = PrivateAttr(_NVIDIAClient)
-    _default_model: str = "mistralai/mixtral-8x7b-instruct-v0.1"
+    _default_model: str = "meta/llama3-8b-instruct"
     base_url: str = Field(
         "https://integrate.api.nvidia.com/v1",
         description="Base url for model listing an invocation",


### PR DESCRIPTION
the current default chat model (endpoint) does not pass nightly tests.

update the default chat model to llama3-8b-instruct, which passes the most feature tests and has the most deployment options.