### PR TITLE
support pydantic v2 and v1 for with_structured_output

### DIFF
--- a/libs/ai-endpoints/scripts/check_pydantic.sh
+++ b/libs/ai-endpoints/scripts/check_pydantic.sh
@@ -14,7 +14,7 @@ fi
 repository_path="$1"
 
 # Search for lines matching the pattern within the specified repository
-result=$(git -C "$repository_path" grep -E '^import pydantic|^from pydantic')
+result=$(git -C "$repository_path" grep -E '^import pydantic|^from pydantic' | grep -v "# ignore: check_pydantic")
 
 # Check if any matching lines were found
 if [ -n "$result" ]; then


### PR DESCRIPTION
`with_structured_output` should accept types built from `langchain_core.pydantic_v1` + `pydantic.v1` + `pydantic`

previously only `langchain_core.pydantic_v1` types were supported.