### PR TITLE
Update min version for langchain-core

### DIFF
--- a/libs/ai-endpoints/poetry.lock
+++ b/libs/ai-endpoints/poetry.lock
@@ -1444,4 +1444,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "eaa16f38cabc695e4ef785ee4d7e87635669ef3323931d2514747a13a3db8ac8"
+content-hash = "6acf7fa18caa83c76267748e07a1f53c0f5eef8a3b1d8cff07169c224b200a2d"

--- a/libs/ai-endpoints/pyproject.toml
+++ b/libs/ai-endpoints/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-langchain-core = ">=0.1.47,<0.3"
+langchain-core = ">=0.2.22,<0.3"
 aiohttp = "^3.9.1"
 pillow = ">=10.0.0,<11.0.0"
 


### PR DESCRIPTION
### Update langchain-core package to support is_basemodel_subclass