### PR TITLE
fix failing test cases for base url

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -17,7 +17,7 @@ from typing import (
     Tuple,
     Union,
 )
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import requests
 from langchain_core.pydantic_v1 import (
@@ -138,7 +138,9 @@ class _NVIDIAClient(BaseModel):
             ):
                 warnings.warn(f"Using {base_url}, ignoring the rest")
 
-            values["base_url"] = base_url
+            values["base_url"] = base_url = urlunparse(
+                (parsed.scheme, parsed.netloc, "v1", None, None, None)
+            )
             values["infer_path"] = values["infer_path"].format(base_url=base_url)
 
         return values


### PR DESCRIPTION
Correcting the url validation logic by adding "v1" to endpoints for failing test cases.