### PR TITLE
update the standard test model from llama 3.1 8b to 3.3 70b

### DIFF
--- a/libs/ai-endpoints/tests/integration_tests/test_standard.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_standard.py
@@ -17,7 +17,7 @@ class TestNVIDIAStandard(ChatModelIntegrationTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": "meta/llama-3.1-8b-instruct"}
+        return {"model": "meta/llama-3.3-70b-instruct"}
 
     @pytest.mark.xfail(reason="anthropic-style list content not supported")
     def test_tool_message_histories_list_content(


### PR DESCRIPTION
this is intended to align w/ the default test model for other tests and address accuracy issues