### PR TITLE
Raspawar/add custom http client

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Generator, List, Literal, Optional, Sequence
 
+import httpx
 from langchain_core.callbacks.manager import Callbacks
 from langchain_core.documents import Document
 from langchain_core.documents.compressor import BaseDocumentCompressor
@@ -32,6 +33,7 @@ class NVIDIARerank(BaseDocumentCompressor):
 
     model_config = ConfigDict(
         validate_assignment=True,
+        arbitrary_types_allowed=True,
     )
 
     _client: _NVIDIAClient = PrivateAttr()
@@ -54,6 +56,10 @@ class NVIDIARerank(BaseDocumentCompressor):
         _DEFAULT_BATCH_SIZE, ge=1, description="The maximum batch size."
     )
 
+    http_client: Optional[httpx.Client] = Field(
+        None, description="Custom HTTP client for making requests"
+    )
+
     def __init__(self, **kwargs: Any):
         """
         Create a new NVIDIARerank document compressor.
@@ -68,6 +74,7 @@ class NVIDIARerank(BaseDocumentCompressor):
             nvidia_api_key (str): The API key to use for connecting to the hosted NIM.
             api_key (str): Alternative to nvidia_api_key.
             base_url (str): The base URL of the NIM to connect to.
+            http_client (httpx.Client): Optional custom HTTP client for making requests.
             truncate (str): "NONE", "END", truncate input text if it exceeds
                             the model's context length. Default is model dependent and
                             is likely to raise an error if an input is too long.
@@ -141,6 +148,7 @@ class NVIDIARerank(BaseDocumentCompressor):
             **({"api_key": api_key} if api_key else {}),  # only pass if set
             infer_path="{base_url}/ranking",
             cls=self.__class__.__name__,
+            http_client=self.http_client,
         )
         # todo: only store the model in one place
         # the model may be updated to a newer name during initialization

--- a/libs/ai-endpoints/poetry.lock
+++ b/libs/ai-endpoints/poetry.lock
@@ -1267,13 +1267,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "8.0.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-8.0.0-py3-none-any.whl", hash = "sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6"},
+    {file = "pytest-8.0.0.tar.gz", hash = "sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c"},
 ]
 
 [package.dependencies]
@@ -1281,7 +1281,7 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<2.0"
+pluggy = ">=1.3.0,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
@@ -1304,6 +1304,24 @@ pytest = ">=7.0.0"
 [package.extras]
 docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+
+[[package]]
+name = "pytest-httpx"
+version = "0.35.0"
+description = "Send responses to httpx."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pytest_httpx-0.35.0-py3-none-any.whl", hash = "sha256:ee11a00ffcea94a5cbff47af2114d34c5b231c326902458deed73f9c459fd744"},
+    {file = "pytest_httpx-0.35.0.tar.gz", hash = "sha256:d619ad5d2e67734abfbb224c3d9025d64795d4b8711116b1a13f72a251ae511f"},
+]
+
+[package.dependencies]
+httpx = "==0.28.*"
+pytest = "==8.*"
+
+[package.extras]
+testing = ["pytest-asyncio (==0.24.*)", "pytest-cov (==6.*)"]
 
 [[package]]
 name = "pytest-mock"
@@ -1791,4 +1809,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "07aeb528161ca4b34877b858f97426d93b6fd00a8793b5c7db6f03a14b29da36"
+content-hash = "89634b6c57b5f68f68c7fdf159d6334cdbe5feaa85a8a5c421bdc291a793372f"

--- a/libs/ai-endpoints/pyproject.toml
+++ b/libs/ai-endpoints/pyproject.toml
@@ -23,7 +23,6 @@ aiohttp = "^3.9.1"
 optional = true
 
 [tool.poetry.group.test.dependencies]
-pytest = "^7.3.0"
 freezegun = "^1.2.2"
 pytest-mock = "^3.10.0"
 syrupy = "^4.0.2"
@@ -32,6 +31,8 @@ pytest-asyncio = "^0.21.1"
 requests-mock = "^1.11.0"
 langchain-tests = "^0.3.7"
 faker = "^24.4.0"
+pytest-httpx = "^0.35.0"
+pytest = "8.0.0"
 
 [tool.poetry.group.codespell]
 optional = true

--- a/libs/ai-endpoints/tests/integration_tests/test_standard.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_standard.py
@@ -17,7 +17,7 @@ class TestNVIDIAStandard(ChatModelIntegrationTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": "meta/llama-3.1-8b-instruct"}
+        return {"model": "meta/llama-3.3-70b-instruct", "temperature": 0}
 
     @pytest.mark.xfail(reason="anthropic-style list content not supported")
     def test_tool_message_histories_list_content(

--- a/libs/ai-endpoints/tests/unit_tests/test_api_key.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_api_key.py
@@ -1,6 +1,7 @@
 import os
+import warnings
 from contextlib import contextmanager
-from typing import Any, Generator
+from typing import Any, Generator, List
 
 import pytest
 from pydantic import SecretStr
@@ -61,16 +62,18 @@ def test_create_without_api_key(public_class: type) -> None:
     with no_env_var("NVIDIA_API_KEY"):
         with pytest.warns(UserWarning) as record:
             public_class()
-        assert len(record) == 1
-        assert "API key is required for the hosted" in str(record[0].message)
+    record_list: List[warnings.WarningMessage] = list(record)
+    assert len(record_list) == 1
+    assert "API key is required for the hosted" in str(record_list[0].message)
 
 
 def test_create_unknown_url_no_api_key(public_class: type) -> None:
     with no_env_var("NVIDIA_API_KEY"):
         with pytest.warns(UserWarning) as record:
             public_class(base_url="https://test_url/v1")
-    assert len(record) == 1
-    assert "Default model is set as" in str(record[0].message)
+    record_list: List[warnings.WarningMessage] = list(record)
+    assert len(record_list) == 1
+    assert "Default model is set as" in str(record_list[0].message)
 
 
 @pytest.mark.parametrize("param", ["nvidia_api_key", "api_key"])

--- a/libs/ai-endpoints/tests/unit_tests/test_completions_models.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_completions_models.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from functools import reduce
 from operator import add
 from typing import Any, Callable, List
@@ -130,23 +131,32 @@ def test_params_unknown(
     request: pytest.FixtureRequest,
 ) -> None:
     request.getfixturevalue(mock_name)
+    record_list: List[warnings.WarningMessage]
 
     with pytest.warns(UserWarning) as record:
         llm = NVIDIA(api_key="BOGUS", init_unknown="INIT")
-    assert len(record) == 1
-    assert "Unrecognized, ignored arguments: {'init_unknown'}" in str(record[0].message)
+    record_list = list(record)
+    assert len(record_list) == 1
+    assert "Unrecognized, ignored arguments: {'init_unknown'}" in str(
+        record_list[0].message
+    )
 
     with pytest.warns(UserWarning) as record:
         func(llm, "IGNORED", arg_unknown="ARG")
-    assert len(record) == 1
-    assert "Unrecognized, ignored arguments: {'arg_unknown'}" in str(record[0].message)
+    record_list = list(record)
+    assert len(record_list) == 1
+    assert "Unrecognized, ignored arguments: {'arg_unknown'}" in str(
+        record_list[0].message
+    )
 
     bound_llm = llm.bind(bind_unknown="BIND")
 
     with pytest.warns(UserWarning) as record:
         func(bound_llm, "IGNORED")
-    assert len(record) == 1
-    assert "Unrecognized, ignored arguments: {'bind_unknown'}" in str(record[0].message)
+    assert len(record_list) == 1
+    assert "Unrecognized, ignored arguments: {'bind_unknown'}" in str(
+        record_list[0].message
+    )
 
 
 def test_identifying_params() -> None:

--- a/libs/ai-endpoints/tests/unit_tests/test_embeddings.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_embeddings.py
@@ -1,4 +1,5 @@
-from typing import Any, Generator
+import warnings
+from typing import Any, Generator, List
 
 import pytest
 from requests_mock import Mocker
@@ -40,8 +41,9 @@ def embedding(requests_mock: Mocker) -> Generator[NVIDIAEmbeddings, None, None]:
     )
     with pytest.warns(UserWarning) as record:
         yield NVIDIAEmbeddings(model=model, nvidia_api_key="a-bogus-key")
-    assert len(record) == 1
-    assert "type is unknown and inference may fail" in str(record[0].message)
+    record_list: List[warnings.WarningMessage] = list(record)
+    assert len(record_list) == 1
+    assert "type is unknown and inference may fail" in str(record_list[0].message)
 
 
 def test_embed_documents_negative_input_int(embedding: NVIDIAEmbeddings) -> None:

--- a/libs/ai-endpoints/tests/unit_tests/test_model.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_model.py
@@ -1,5 +1,6 @@
+import warnings
 from itertools import chain
-from typing import Any
+from typing import Any, List
 
 import pytest
 from requests_mock import Mocker
@@ -97,8 +98,9 @@ def test_aliases(alias: str, client: Any) -> None:
     with pytest.warns(UserWarning) as record:
         x = client(model=alias, nvidia_api_key="a-bogus-key")
         assert x.model == x._client.mdl_name
-    assert isinstance(record[0].message, Warning)
-    assert "deprecated" in record[0].message.args[0]
+    record_list: List[warnings.WarningMessage] = list(record)
+    assert isinstance(record_list[0].message, Warning)
+    assert "deprecated" in record_list[0].message.args[0]
 
 
 def test_known(public_class: type) -> None:
@@ -124,9 +126,10 @@ def test_known_unknown(public_class: type, known_unknown: str) -> None:
     with pytest.warns(UserWarning) as record:
         x = public_class(model=known_unknown, nvidia_api_key="a-bogus-key")
         assert x.model == known_unknown
-    assert isinstance(record[0].message, Warning)
-    assert "Found" in record[0].message.args[0]
-    assert "unknown" in record[0].message.args[0]
+    record_list: List[warnings.WarningMessage] = list(record)
+    assert isinstance(record_list[0].message, Warning)
+    assert "Found" in record_list[0].message.args[0]
+    assert "unknown" in record_list[0].message.args[0]
 
 
 def test_unknown_unknown(public_class: type, empty_v1_models: None) -> None:
@@ -148,8 +151,8 @@ def test_default_known(public_class: type, known_unknown: str) -> None:
     with pytest.warns(UserWarning) as record:
         x = public_class(base_url="http://localhost:8000/v1")
         assert x.model == known_unknown
-    assert len(record) == 1
-    assert "Default model is set as: mock-model" in str(record[0].message)
+    record_list: List[warnings.WarningMessage] = list(record)
+    assert "Default model is set as: mock-model" in str(record_list[0].message)
 
 
 def test_default_lora(public_class: type) -> None:

--- a/libs/ai-endpoints/tests/unit_tests/test_ranking.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_ranking.py
@@ -1,31 +1,16 @@
 import warnings
 from typing import Any, Literal, Optional
 
+import httpx
 import pytest
 from langchain_core.documents import Document
+from pytest_httpx import HTTPXMock
 from requests_mock import Mocker
 
 from langchain_nvidia_ai_endpoints import NVIDIARerank
 
 
-@pytest.fixture(autouse=True)
-def mock_v1_models(requests_mock: Mocker) -> None:
-    requests_mock.get(
-        "https://integrate.api.nvidia.com/v1/models",
-        json={
-            "data": [
-                {
-                    "id": "mock-model",
-                    "object": "model",
-                    "created": 1234567890,
-                    "owned_by": "OWNER",
-                }
-            ]
-        },
-    )
-
-
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_v1_ranking(requests_mock: Mocker) -> None:
     requests_mock.post(
         "https://integrate.api.nvidia.com/v1/ranking",
@@ -48,6 +33,7 @@ def mock_v1_ranking(requests_mock: Mocker) -> None:
 def test_truncate(
     requests_mock: Mocker,
     truncate: Optional[Literal["END", "NONE"]],
+    mock_v1_ranking: None,
 ) -> None:
     truncate_param = {}
     if truncate:
@@ -72,6 +58,93 @@ def test_truncate(
 
 
 @pytest.mark.parametrize("truncate", [True, False, 1, 0, 1.0, "START", "BOGUS"])
-def test_truncate_invalid(truncate: Any) -> None:
+def test_truncate_invalid(truncate: Any, mock_v1_ranking: None) -> None:
     with pytest.raises(ValueError):
         NVIDIARerank(truncate=truncate)
+
+
+class CustomTestClient(httpx.Client):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.custom_headers = {"X-Custom-Header": "test-value"}
+
+    def request(self, *args, **kwargs) -> httpx.Response:
+        # Add custom headers to each request
+        if "headers" in kwargs:
+            kwargs["headers"].update(self.custom_headers)
+        else:
+            kwargs["headers"] = self.custom_headers
+        return super().request(*args, **kwargs)
+
+
+def test_rerank_with_custom_client(httpx_mock: HTTPXMock, mock_model: str) -> None:
+    """
+    Test that both available models (GET request) and compress_documents (POST request)
+    """
+    httpx_mock.add_response(
+        method="GET",
+        url="https://integrate.api.nvidia.com/v1/models",
+        json={
+            "data": [
+                {
+                    "id": mock_model,
+                    "object": "model",
+                    "created": 1234567890,
+                    "owned_by": "OWNER",
+                    "type": "reranking",
+                }
+            ]
+        },
+        headers={"Authorization": "Bearer BOGUS", "X-Custom-Header": "test-value"},
+    )
+
+    custom_client = CustomTestClient()
+    client = NVIDIARerank(api_key="BOGUS", model=mock_model, http_client=custom_client)
+
+    _ = client.available_models
+
+    calls = httpx_mock.get_requests()
+    models_requests = [req for req in calls if "/v1/models" in str(req.url)]
+    assert len(models_requests) > 0, "No requests made to /models endpoint"
+    for req in models_requests:
+        assert req.headers.get("authorization") == "Bearer BOGUS"
+        assert req.headers.get("x-custom-header") == "test-value"
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://integrate.api.nvidia.com/v1/ranking",
+        json={"rankings": [{"index": 0, "logit": 5.5}]},
+    )
+
+    compress_response = client.compress_documents(
+        documents=[Document(page_content="Test compress.")], query="What is compress?"
+    )
+    assert (
+        len(compress_response) == 1
+    ), "Expected one ranking result from compress_documents"
+
+    post_calls = [
+        req
+        for req in httpx_mock.get_requests()
+        if req.method == "POST" and "/v1/ranking" in str(req.url)
+    ]
+    assert len(post_calls) > 0, "No POST requests made to /ranking endpoint"
+    for req in post_calls:
+        assert req.headers.get("authorization") == "Bearer BOGUS"
+        assert req.headers.get("x-custom-header") == "test-value"
+
+
+def test_rerank_client_error(httpx_mock: HTTPXMock, mock_model: str) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url="https://integrate.api.nvidia.com/v1/models",
+        status_code=401,
+        json={"detail": "Invalid API key"},
+    )
+
+    custom_client = CustomTestClient()
+
+    with pytest.raises(Exception) as exc_info:
+        NVIDIARerank(api_key="INVALID", model=mock_model, http_client=custom_client)
+
+    assert "Invalid API key" in str(exc_info.value)

--- a/libs/ai-endpoints/tests/unit_tests/test_register_model.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_register_model.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import List
 
 import pytest
 
@@ -50,10 +51,11 @@ def test_duplicate_model_warns() -> None:
     register_model(model)
     with pytest.warns(UserWarning) as record:
         register_model(model)
-    assert len(record) == 1
-    assert isinstance(record[0].message, UserWarning)
-    assert "already registered" in str(record[0].message)
-    assert "Overriding" in str(record[0].message)
+    record_list: List[warnings.WarningMessage] = list(record)
+    assert len(record_list) == 1
+    assert isinstance(record_list[0].message, UserWarning)
+    assert "already registered" in str(record_list[0].message)
+    assert "Overriding" in str(record_list[0].message)
 
 
 def test_registered_model_usable(public_class: type, mock_model: str) -> None:
@@ -82,9 +84,10 @@ def test_registered_model_without_client_usable(public_class: type) -> None:
     register_model(model)
     with pytest.warns(UserWarning) as record:
         public_class(model=id, nvidia_api_key="a-bogus-key")
-    assert len(record) == 1
-    assert isinstance(record[0].message, UserWarning)
-    assert "Unable to determine validity" in str(record[0].message)
+    record_list: List[warnings.WarningMessage] = list(record)
+    assert len(record_list) == 1
+    assert isinstance(record_list[0].message, UserWarning)
+    assert "Unable to determine validity" in str(record_list[0].message)
 
 
 def test_missing_endpoint() -> None:

--- a/libs/ai-endpoints/tests/unit_tests/test_statics.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_statics.py
@@ -1,4 +1,5 @@
-from typing import Any
+import warnings
+from typing import Any, List
 
 import pytest
 
@@ -29,5 +30,6 @@ def test_model_table_integrity_name_id(entry: str) -> None:
 def test_determine_model_deprecated_alternative_warns(alias: str) -> None:
     with pytest.warns(UserWarning) as record:
         determine_model(alias)
-    assert len(record) == 1
-    assert f"Model {alias} is deprecated" in str(record[0].message)
+    record_list: List[warnings.WarningMessage] = list(record)
+    assert len(record_list) == 1
+    assert f"Model {alias} is deprecated" in str(record_list[0].message)

--- a/libs/ai-endpoints/tests/unit_tests/test_structured_output.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_structured_output.py
@@ -28,8 +28,9 @@ def test_method() -> None:
                 message=".*not known to support structured output.*",
             )
             ChatNVIDIA(api_key="BOGUS").with_structured_output(Joke, method="json_mode")
-        assert len(record) == 1
-        assert "unnecessary" in str(record[0].message)
+        record_list: List[warnings.WarningMessage] = list(record)
+        assert len(record_list) == 1
+        assert "unnecessary" in str(record_list[0].message)
 
 
 def test_include_raw() -> None:
@@ -69,8 +70,9 @@ def test_unknown_warns(empty_v1_models: None) -> None:
         ChatNVIDIA(
             api_key="BOGUS", model=unstructured_model[0].id
         ).with_structured_output(Joke)
-    assert len(record) == 1
-    assert "not known to support structured output" in str(record[0].message)
+    record_list: List[warnings.WarningMessage] = list(record)
+    assert len(record_list) == 1
+    assert "not known to support structured output" in str(record_list[0].message)
 
 
 def test_enum_negative() -> None:
@@ -86,9 +88,9 @@ def test_enum_negative() -> None:
             category=UserWarning,
             message=".*not known to support structured output.*",
         )
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError) as exc_info:
             llm.with_structured_output(Choices)
-    assert "only contain string choices" in str(e.value)
+    assert "only contain string choices" in str(exc_info.value)
 
 
 class Choices(enum.Enum):


### PR DESCRIPTION
### Add Custom HTTP Client

**What's Changed:**
- Updated the reranker to support the httpx client.
- Added unit tests for the custom HTTP client.
- updated pytest==8.0.0 as pytest-httpx depends on that

**Testing:**
- Run the unit tests to ensure the new HTTP client works correctly.
- Verify that the reranker behaves as expected with these changes.

cc: @mattf @dglogo @sumitb