### PR TITLE
Changed api versioning detection.

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -147,7 +147,7 @@ class _NVIDIAClient(BaseModel):
                 raise ValueError(f"Invalid base_url format. {expected_format} Got: {v}")
 
             normalized_path = parsed.path.rstrip("/")
-            if not "/v1" in normalized_path:
+            if "/v1" not in normalized_path:
                 warnings.warn(
                     f"{v} does not contain in /v1, you may "
                     "have inference and listing issues"
@@ -157,7 +157,6 @@ class _NVIDIAClient(BaseModel):
             v = urlunparse(
                 (parsed.scheme, parsed.netloc, normalized_path, None, None, None)
             )
-        print(v)
         return v
 
     # final validation after model is constructed

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -149,7 +149,7 @@ class _NVIDIAClient(BaseModel):
             normalized_path = parsed.path.rstrip("/")
             if "/v1" not in normalized_path:
                 warnings.warn(
-                    f"{v} does not contain in /v1, you may "
+                    f"{v} does not contain /v1, you may "
                     "have inference and listing issues"
                 )
                 normalized_path += "/v1"

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -147,9 +147,9 @@ class _NVIDIAClient(BaseModel):
                 raise ValueError(f"Invalid base_url format. {expected_format} Got: {v}")
 
             normalized_path = parsed.path.rstrip("/")
-            if not normalized_path.endswith("/v1"):
+            if not "/v1" in normalized_path:
                 warnings.warn(
-                    f"{v} does not end in /v1, you may "
+                    f"{v} does not contain in /v1, you may "
                     "have inference and listing issues"
                 )
                 normalized_path += "/v1"
@@ -157,7 +157,7 @@ class _NVIDIAClient(BaseModel):
             v = urlunparse(
                 (parsed.scheme, parsed.netloc, normalized_path, None, None, None)
             )
-
+        print(v)
         return v
 
     # final validation after model is constructed

--- a/libs/ai-endpoints/tests/unit_tests/test_base_url.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_base_url.py
@@ -112,7 +112,7 @@ def test_param_base_url_not_hosted(public_class: type, base_url: str) -> None:
         "http://0.0.0.0:8888/rankings",
         "http://localhost:8888/embeddings/",
         "http://0.0.0.0:8888/rankings/",
-        "http://localhost:8888/chat/completions"
+        "http://localhost:8888/chat/completions",
     ],
 )
 def test_expect_warn(public_class: type, base_url: str) -> None:

--- a/libs/ai-endpoints/tests/unit_tests/test_base_url.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_base_url.py
@@ -99,7 +99,7 @@ def test_param_base_url_hosted(public_class: type, base_url: str) -> None:
     ],
 )
 def test_param_base_url_not_hosted(public_class: type, base_url: str) -> None:
-    warnings.filterwarnings("ignore", r".*does not end in /v1.*")
+    warnings.filterwarnings("ignore", r".*does not contain /v1.*")
     with no_env_var("NVIDIA_BASE_URL"):
         client = public_class(model="model1", base_url=base_url)
         assert not client._client.is_hosted
@@ -112,16 +112,14 @@ def test_param_base_url_not_hosted(public_class: type, base_url: str) -> None:
         "http://0.0.0.0:8888/rankings",
         "http://localhost:8888/embeddings/",
         "http://0.0.0.0:8888/rankings/",
-        "http://localhost:8888/chat/completions",
-        "http://localhost:8080/v1/embeddings",
-        "http://0.0.0.0:8888/v1/rankings",
+        "http://localhost:8888/chat/completions"
     ],
 )
 def test_expect_warn(public_class: type, base_url: str) -> None:
     with pytest.warns(UserWarning) as record:
         public_class(model="model1", base_url=base_url)
     assert len(record) == 1
-    assert "does not end in /v1" in str(record[0].message)
+    assert "does not contain /v1" in str(record[0].message)
 
 
 def test_default_hosted(public_class: type) -> None:


### PR DESCRIPTION
URLs like `/v1/asdf/chat/completions` are just openai spec compliant while still maintaining the api version in the URL.