### PR TITLE
add support for llama-4 models

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -513,6 +513,16 @@ CHAT_MODEL_TABLE = {
         model_type="chat",
         client="ChatNVIDIA",
     ),
+    "meta/llama-4-maverick-17b-128e-instruct": Model(
+        id="meta/llama-4-maverick-17b-128e-instruct",
+        model_type="chat",
+        client="ChatNVIDIA",
+    ),
+    "meta/llama-4-scout-17b-16e-instruct": Model(
+        id="meta/llama-4-scout-17b-16e-instruct",
+        model_type="chat",
+        client="ChatNVIDIA",
+    ),
 }
 
 QA_MODEL_TABLE = {

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -513,16 +513,6 @@ CHAT_MODEL_TABLE = {
         model_type="chat",
         client="ChatNVIDIA",
     ),
-    "meta/llama-4-maverick-17b-128e-instruct": Model(
-        id="meta/llama-4-maverick-17b-128e-instruct",
-        model_type="chat",
-        client="ChatNVIDIA",
-    ),
-    "meta/llama-4-scout-17b-16e-instruct": Model(
-        id="meta/llama-4-scout-17b-16e-instruct",
-        model_type="chat",
-        client="ChatNVIDIA",
-    ),
 }
 
 QA_MODEL_TABLE = {
@@ -605,6 +595,16 @@ VLM_MODEL_TABLE = {
         model_type="vlm",
         client="ChatNVIDIA",
         endpoint="https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-90b-vision-instruct/chat/completions",
+    ),
+    "meta/llama-4-maverick-17b-128e-instruct": Model(
+        id="meta/llama-4-maverick-17b-128e-instruct",
+        model_type="vlm",
+        client="ChatNVIDIA",
+    ),
+    "meta/llama-4-scout-17b-16e-instruct": Model(
+        id="meta/llama-4-scout-17b-16e-instruct",
+        model_type="vlm",
+        client="ChatNVIDIA",
     ),
 }
 


### PR DESCRIPTION
## Support for:

- meta/llama-4-maverick-17b-128e-instruct
- meta/llama-4-scout-17b-16e-instruct

Integrations test case:
returning a generic "Bad request" + "Inference error" message for: negative max_tokens, Temperature, top_p
Have raised a bug internally.

cc: @dglogo, @mattf 