### PR TITLE
Updated warnings for api version check.

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -144,13 +144,16 @@ class _NVIDIAClient(BaseModel):
             # Ensure scheme and netloc (domain name) are present
             if not (parsed.scheme and parsed.netloc):
                 expected_format = "Expected format is: http://host:port"
-                raise ValueError(f"Invalid base_url format. {expected_format} Got: {v}")
+                warnings.warn(
+                    f"The provided url appears incorrect. Expected: {expected_format} Got: {v}"
+                )
 
             normalized_path = parsed.path.rstrip("/")
             if not normalized_path.endswith("/v1"):
                 warnings.warn(
-                    f"{v} does not end in /v1, you may "
-                    "have inference and listing issues"
+                    f"{v} does not end in /v1, you may have inference and listing issues. "
+                    "This check will be deprecated in the next release. "
+                    "Please ensure /v1 is appended to the provided URL",
                 )
                 normalized_path += "/v1"
 

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -145,13 +145,15 @@ class _NVIDIAClient(BaseModel):
             if not (parsed.scheme and parsed.netloc):
                 expected_format = "Expected format is: http://host:port"
                 warnings.warn(
-                    f"The provided url appears incorrect. Expected: {expected_format} Got: {v}"
+                    "The provided url appears incorrect. "
+                    f"Expected: {expected_format} Got: {v}"
                 )
 
             normalized_path = parsed.path.rstrip("/")
             if not normalized_path.endswith("/v1"):
                 warnings.warn(
-                    f"{v} does not end in /v1, you may have inference and listing issues. "
+                    f"{v} does not end in /v1, "
+                    "you may have inference and listing issues. "
                     "This check will be deprecated in the next release. "
                     "Please ensure /v1 is appended to the provided URL",
                 )

--- a/libs/ai-endpoints/tests/unit_tests/test_base_url.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_base_url.py
@@ -71,11 +71,11 @@ def test_base_url_priority(public_class: type) -> None:
         "http:/oops",
     ],
 )
-def test_param_base_url_negative(public_class: type, base_url: str) -> None:
-    with no_env_var("NVIDIA_BASE_URL"):
-        with pytest.raises(ValueError) as e:
-            public_class(base_url=base_url)
-        assert "Invalid base_url" in str(e.value)
+def test_expect_warn_base_url(public_class: type, base_url: str) -> None:
+    with pytest.warns(UserWarning) as record:
+        public_class(model="model1", base_url=base_url)
+    assert len(record) > 0
+    assert "url appears incorrect" in str(record[0].message)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
replaces #148 

maintain the current behavior for now, but deprecate the feature in the following release. 