### PR TITLE
Added option to  skip api  url checking.

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -150,7 +150,10 @@ class _NVIDIAClient(BaseModel):
                 )
 
             normalized_path = parsed.path.rstrip("/")
-            if not normalized_path.endswith("/v1"):
+            skip_api_version_check = os.environ.get(
+                "NVIDIA_APPEND_API_VERSION", ""
+            ) in ["false", "False", "0"]
+            if not skip_api_version_check and not normalized_path.endswith("/v1"):
                 warnings.warn(
                     f"{v} does not end in /v1, "
                     "you may have inference and listing issues. "

--- a/libs/ai-endpoints/tests/unit_tests/test_base_url.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_base_url.py
@@ -164,15 +164,22 @@ def test_expect_skip_check(public_class: type, base_url: str, false_value: str) 
         "http://0.0.0.0:8888/v1/rankings",
     ],
 )
-@pytest.mark.parametrize("true_value", ["true", "True", "yes", "1", "anything", "enabled", "on", ""])
-def test_expect_not_skip_check(public_class: type, base_url: str, true_value: str) -> None:
+@pytest.mark.parametrize(
+    "true_value",
+    ["true", "True", "yes", "1", "anything", "enabled", "on", ""],
+)
+def test_expect_not_skip_check(
+    public_class: type, base_url: str, true_value: str
+) -> None:
     warnings.filterwarnings("ignore", r".*does not end in /v1.*")
     orig = os.environ.get("NVIDIA_APPEND_API_VERSION", None)
 
     try:
         os.environ["NVIDIA_APPEND_API_VERSION"] = true_value
         obj = public_class(model="model1", base_url=base_url)
-        assert obj.base_url.rstrip("/").endswith("/v1"), f"Expected {obj.base_url} to end with '/v1'"
+        assert obj.base_url.rstrip("/").endswith(
+            "/v1"
+        ), f"Expected {obj.base_url} to end with '/v1'"
     finally:
         warnings.resetwarnings()
         if orig is None:

--- a/libs/ai-endpoints/tests/unit_tests/test_base_url.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_base_url.py
@@ -124,6 +124,32 @@ def test_expect_warn(public_class: type, base_url: str) -> None:
     assert "does not end in /v1" in str(record[0].message)
 
 
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://localhost:8888/embeddings",
+        "http://0.0.0.0:8888/rankings",
+        "http://localhost:8888/embeddings/",
+        "http://0.0.0.0:8888/rankings/",
+        "http://localhost:8888/chat/completions",
+        "http://localhost:8080/v1/embeddings",
+        "http://0.0.0.0:8888/v1/rankings",
+    ],
+)
+def test_expect_skip_check(public_class: type, base_url: str) -> None:
+    orig = os.environ.get("NVIDIA_APPEND_API_VERSION", None)
+    warnings.filterwarnings("error")
+
+    os.environ["NVIDIA_APPEND_API_VERSION"] = "false"
+    public_class(model="model1", base_url=base_url)
+
+    warnings.resetwarnings()
+    if orig is None:
+        del os.environ["NVIDIA_APPEND_API_VERSION"]
+    else:
+        os.environ["NVIDIA_APPEND_API_VERSION"] = orig
+
+
 def test_default_hosted(public_class: type) -> None:
     x = public_class(api_key="BOGUS")
     assert x._client.is_hosted


### PR DESCRIPTION
Setting `APPEND_NVIDIA_API_VERSION` to `False`, `false`, or `0` will disable the `/v1` check.

Unit test added to verify this behavior.