### PR TITLE
openai spec updates

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -306,13 +306,8 @@ class ChatNVIDIA(BaseChatModel):
                 model="meta-llama3-8b-instruct"
             )
         """
-        # Track which parameter name was used
-        if "max_tokens" in kwargs and "max_completion_tokens" in kwargs:
-            raise ValueError("Cannot specify both max_tokens and max_completion_tokens")
-        self._token_param_name = "max_tokens" if "max_tokens" in kwargs else "max_completion_tokens"
-        
         # Show deprecation warning if max_tokens was used
-        if self._token_param_name == "max_tokens":
+        if "max_tokens" in kwargs:
             warnings.warn(
                 "The 'max_tokens' parameter is deprecated and will be removed in a future version. "
                 "Please use 'max_completion_tokens' instead.",
@@ -376,8 +371,9 @@ class ChatNVIDIA(BaseChatModel):
             ls_model_name=self.model or "UNKNOWN",
             ls_model_type="chat",
             ls_temperature=params.get("temperature", self.temperature),
-            ls_max_tokens=params.get("max_tokens", self.max_tokens) or params.get(
-                "max_completion_tokens", self.max_tokens
+            # TODO: remove max_tokens once all models support max_completion_tokens
+            ls_max_tokens=params.get("max_completion_tokens", self.max_tokens) or params.get(
+                "max_tokens", self.max_tokens
             ),
             # mypy error: Extra keys ("ls_top_p", "ls_seed")
             #  for TypedDict "LangSmithParams"  [typeddict-item]
@@ -558,7 +554,7 @@ class ChatNVIDIA(BaseChatModel):
         payload: Dict[str, Any] = {
             "model": self.model,
             "temperature": self.temperature,
-            self._token_param_name: self.max_tokens,  # Use the exact parameter name that was passed
+            "max_tokens": self.max_tokens, # TODO: change key to max_completion_tokens once all models support it
             "top_p": self.top_p,
             "seed": self.seed,
             "stop": self.stop,

--- a/libs/ai-endpoints/tests/unit_tests/test_chat_models.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_chat_models.py
@@ -3,6 +3,7 @@
 
 import pytest
 from requests_mock import Mocker
+import warnings
 
 from langchain_nvidia_ai_endpoints.chat_models import ChatNVIDIA
 
@@ -45,3 +46,23 @@ def test_integration_initialization() -> None:
 def test_unavailable(empty_v1_models: None) -> None:
     with pytest.warns(UserWarning, match="Model not-a-real-model is unknown"):
         ChatNVIDIA(api_key="BOGUS", model="not-a-real-model")
+
+
+def test_max_tokens_deprecation_warning() -> None:
+    """Test that using max_tokens raises a deprecation warning."""
+    with pytest.warns(
+        DeprecationWarning,
+        match="The 'max_tokens' parameter is deprecated and will be removed in a future version",
+    ):
+        ChatNVIDIA(model="meta/llama2-70b", max_tokens=50, nvidia_api_key="nvapi-...")
+
+
+def test_max_completion_tokens() -> None:
+    """Test that max_completion_tokens works without warning."""
+    # Filter out unrelated warnings
+    
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        llm = ChatNVIDIA(model="meta/llama2-70b", max_completion_tokens=50, nvidia_api_key="nvapi-...")
+        assert len(w) == 0
+        assert llm.max_tokens == 50  # max_tokens should be set to the same value


### PR DESCRIPTION
### Support for `max_completion_tokens` as a class parameter in `ChatNVIDIA`.

This change will internally accept both `max_tokens` and `max_completion_tokens` as a param and convert this to `max_tokens` in payload for requests. 

This will be changed in future releases to use `max_completion_tokens` instead once all models support this parameter. 