### PR TITLE
relax nemotron thinking warning for nvdev models

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -954,9 +954,11 @@ class ChatNVIDIA(BaseChatModel):
                 response = no_thinking_model.invoke("Hello")
         """
         # check if the model supports thinking mode, warn if it does not
-        if (self._client.model and 
-            not self._client.model.supports_thinking and 
-            not self.model.startswith("nvdev/")):
+        if (
+            self._client.model
+            and not self._client.model.supports_thinking
+            and not self.model.startswith("nvdev/")
+        ):
             warnings.warn(
                 f"Model '{self.model}' does not support thinking mode. "
                 "The thinking mode configuration will be ignored."

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -954,7 +954,9 @@ class ChatNVIDIA(BaseChatModel):
                 response = no_thinking_model.invoke("Hello")
         """
         # check if the model supports thinking mode, warn if it does not
-        if self._client.model and not self._client.model.supports_thinking:
+        if (self._client.model and 
+            not self._client.model.supports_thinking and 
+            not self.model.startswith("nvdev/")):
             warnings.warn(
                 f"Model '{self.model}' does not support thinking mode. "
                 "The thinking mode configuration will be ignored."

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -954,16 +954,11 @@ class ChatNVIDIA(BaseChatModel):
                 response = no_thinking_model.invoke("Hello")
         """
         # check if the model supports thinking mode, warn if it does not
-        if (
-            self._client.model
-            and not self._client.model.supports_thinking
-            and not self.model.startswith("nvdev/")
-        ):
+        if self._client.model and not self._client.model.supports_thinking:
             warnings.warn(
                 f"Model '{self.model}' does not support thinking mode. "
                 "The thinking mode configuration will be ignored."
             )
-            return self
 
         return super().bind(
             thinking_mode=enabled,


### PR DESCRIPTION
This change will let users use the `with_thinking_mode `with a warning in case the model is not known to support thinking. This was done keeping `nvdev` models in mind so that users don't need to register models every time with thinking support to use it. 