### PR TITLE
adding an optional param stream_options to let user disable stream_op…

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -274,8 +274,8 @@ class ChatNVIDIA(BaseChatModel):
     seed: Optional[int] = Field(None, description="The seed for deterministic results")
     stop: Optional[Sequence[str]] = Field(None, description="Stop words (cased)")
     stream_options: Optional[Dict[str, Any]] = Field(
-        {'include_usage': True}, 
-        description="Stream options for the model. Set to None to disable"
+        {"include_usage": True},
+        description="Stream options for the model. Set to None to disable",
     )
 
     def __init__(self, **kwargs: Any):
@@ -440,13 +440,10 @@ class ChatNVIDIA(BaseChatModel):
         # remove stream_options if user set it to None or if model doesn't support it
         # todo: get vlm endpoints fixed and remove this
         #       vlm endpoints do not accept standard stream_options parameter
-        if (
-            self.stream_options is None
-            or (
-                self._client.model
-                and self._client.model.model_type
-                and self._client.model.model_type in ["nv-vlm", "qa"]
-            )
+        if self.stream_options is None or (
+            self._client.model
+            and self._client.model.model_type
+            and self._client.model.model_type in ["nv-vlm", "qa"]
         ):
             payload.pop("stream_options", None)
         for response in self._client.get_req_stream(


### PR DESCRIPTION
some chat models don't support `stream_options`. This change let's user pass value of `stream_options`. Setting it to none will skip passing this in payload.