### PR TITLE
Add support for Llama 3.3 Nemotron Super 49b v1.5

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -527,6 +527,12 @@ CHAT_MODEL_TABLE = {
         client="ChatNVIDIA",
         supports_thinking=True,
     ),
+    "nvidia/llama-3.3-nemotron-super-49b-v1.5": Model(
+        id="nvidia/llama-3.3-nemotron-super-49b-v1.5",
+        model_type="chat",
+        client="ChatNVIDIA",
+        supports_thinking=True,
+    ),
     "moonshotai/kimi-k2-instruct": Model(
         id="moonshotai/kimi-k2-instruct",
         model_type="chat",

--- a/libs/ai-endpoints/pyproject.toml
+++ b/libs/ai-endpoints/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-nvidia-ai-endpoints"
-version = "0.3.14"
+version = "0.3.15"
 description = "An integration package connecting NVIDIA AI Endpoints and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
Add support for [Llama 3.3 Nemotron Super 49b v1.5 NIM](https://build.nvidia.com/nvidia/llama-3_3-nemotron-super-49b-v1_5).