### PR TITLE
Add tool call support to llama-3.3-nemotron-super-49b v1 and v1.5

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -526,12 +526,14 @@ CHAT_MODEL_TABLE = {
         model_type="chat",
         client="ChatNVIDIA",
         supports_thinking=True,
+        supports_tools=True,
     ),
     "nvidia/llama-3.3-nemotron-super-49b-v1.5": Model(
         id="nvidia/llama-3.3-nemotron-super-49b-v1.5",
         model_type="chat",
         client="ChatNVIDIA",
         supports_thinking=True,
+        supports_tools=True,
     ),
     "moonshotai/kimi-k2-instruct": Model(
         id="moonshotai/kimi-k2-instruct",


### PR DESCRIPTION
- Add tool call support to [nvidia/llama-3.3-nemotron-super-49b-v1](https://build.nvidia.com/nvidia/llama-3_3-nemotron-super-49b-v1) and [nvidia/llama-3.3-nemotron-super-49b-v1.5](https://build.nvidia.com/nvidia/llama-3_3-nemotron-super-49b-v1_5).