### PR TITLE
fix: handle duplicate model IDs in available_models for ChatNVIDIA

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -213,11 +213,9 @@ class _NVIDIAClient(BaseModel):
                     # we override the infer_path to use the custom endpoint
                     self.infer_path = model.endpoint
             else:
-                candidates = [
-                    model
-                    for model in self.available_models
-                    if model.id == self.mdl_name
-                ]
+                unique_models = {model.id: model for model in self.available_models}.values()
+                candidates = [model for model in unique_models if model.id == self.mdl_name]
+
                 assert len(candidates) <= 1, (
                     f"Multiple candidates for {self.mdl_name} "
                     f"in `available_models`: {candidates}"
@@ -315,7 +313,7 @@ class _NVIDIAClient(BaseModel):
     def available_models(self) -> list[Model]:
         """List the available models that can be invoked."""
         if self._available_models is not None:
-            return self._available_models
+            return list({model.id: model for model in self._available_models}.values())
 
         response, _ = self._get(self.listing_path.format(base_url=self.base_url))
         # expecting -


### PR DESCRIPTION
### Summary

This PR resolves an `AssertionError` that occurs when duplicate entries for a model ID (e.g., `openai/gpt-oss-20b`) are found in the `available_models` list. The issue was traced to both `ChatNVIDIA` and `_NVIDIAClient`, which did not handle deduplication of models returned from the NVIDIA API.

---

### Root Cause

The current implementation assumes that each model ID appears only once in the `available_models` list. However, in real-world usage, the NVIDIA model listing API may return duplicate entries, causing this assertion to fail:

### Fixes Applied
1. _NVIDIAClient.__init__ (in _common.py)
Deduplicated available_models by model.id before filtering for mdl_name

Ensures at most one unique model is selected, avoiding false-positive assertions

2. _NVIDIAClient.available_models property
Always returns a deduplicated list of Model objects using model.id as the key

Ensures downstream consumers (like ChatNVIDIA) receive clean model lists

3. ChatNVIDIA.with_structured_output() (in chat_model.py)
Patched the filtering logic to deduplicate available_models before checking compatibility

Prevents structured output wrapping from failing due to redundant models

### Impact
1. Fixes crashes during instantiation of ChatNVIDIA(model="openai/gpt-oss-20b")
2. Ensures robust handling of API responses with duplicates
3. Backward-compatible — existing logic preserved

Before
`model = ChatNVIDIA(model="openai/gpt-oss-20b")`
`AssertionError due to multiple candidates with same ID`

After
`model = ChatNVIDIA(model="openai/gpt-oss-20b")`

### Works as expected
```
print(model.invoke("Hello!"))
```