### PR TITLE
fix: Fix vlm test case to not allow detail to be None

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -179,6 +179,13 @@ def _nv_vlm_adjust_input(
                         isinstance(part["image_url"], dict)
                         and "url" in part["image_url"]
                     ):
+                        if "detail" in part["image_url"]:
+                            detail = part["image_url"]["detail"]
+                            if detail not in ["auto", "low", "high"]:
+                                raise ValueError(
+                                    f"Invalid detail value: {detail!r}. "
+                                    "Must be one of 'auto', 'low', or 'high'. "
+                                )
                         url = _url_to_b64_string(part["image_url"]["url"])
                         if model_type == "nv-vlm":
                             part["image_url"] = url

--- a/libs/ai-endpoints/tests/integration_tests/test_vlm_models.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_vlm_models.py
@@ -86,8 +86,8 @@ def test_vlm_input_style(
 
 @pytest.mark.parametrize(
     "detail",
-    ["low", "high", "auto", None],
-    ids=["low", "high", "auto", "none"],
+    ["low", "high", "auto"],
+    ids=["low", "high", "auto"],
 )
 def test_vlm_detail_accepted(
     vlm_model: str,
@@ -113,6 +113,37 @@ def test_vlm_detail_accepted(
     assert isinstance(response, BaseMessage)
     assert isinstance(response.content, str)
     # assert "cat" in response.content.lower()
+
+
+@pytest.mark.parametrize(
+    "invalid_detail",
+    [None, "None", "medium", "HIGH", ""],
+    ids=["None", "None-str", "medium", "HIGH", ""],
+)
+def test_vlm_detail_invalid(
+    vlm_model: str,
+    mode: dict,
+    invalid_detail: str,
+) -> None:
+    """Test that invalid detail values raise ValueError."""
+    chat = ChatNVIDIA(model=vlm_model, **mode)
+
+    with pytest.raises(ValueError, match="Invalid detail value"):
+        chat.invoke(
+            [
+                HumanMessage(
+                    content=[
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "tests/data/nvidia-picasso.jpg",
+                                "detail": invalid_detail,
+                            },
+                        }
+                    ]
+                )
+            ]
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The previous test case allows for the detail to be ```None```. However, this is not accepted by the CI test model ```meta/llama-3.2-11b-vision-instruct```.
According to [the schema for ImageURL](https://python.langchain.com/api_reference/core/prompt_values/langchain_core.prompt_values.ImageURL.html#langchain_core.prompt_values.ImageURL.detail), it is not valid for the detail field to be ```None```. Thus, this PR removes ```None``` from the ```test_vlm_detail_accepted``` test case and adds validation to raise `ValueError` when invalid detail values are provided. 