### PR TITLE
fix: Add supports_tool to meta/llama-3.2-1b-instruct

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -402,6 +402,7 @@ CHAT_MODEL_TABLE = {
         id="meta/llama-3.2-1b-instruct",
         model_type="chat",
         client="ChatNVIDIA",
+        supports_tools=True,
         supports_structured_output=True,
     ),
     "meta/llama-3.2-3b-instruct": Model(


### PR DESCRIPTION
Add supports_tool for the model as the model card from https://build.nvidia.com/meta/llama-3.2-1b-instruct shows the tool use benchmark results.