### PR TITLE
fix: Catch error object in streaming responses instead of returning empty chunks

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -535,6 +535,13 @@ class _NVIDIAClient(BaseModel):
         finish_reason_holder: Optional[str] = None
         is_stopped = False
         for msg in msg_list:
+            # Check for errors in streaming response
+            if "error" in msg and "choices" not in msg:
+                error_info = msg.get("error")
+                if isinstance(error_info, dict) and error_info.get("object") == "error":
+                    error_msg = error_info.get("message", "Unknown error")
+                    error_type = error_info.get("type", "Error")
+                    raise Exception(f"{error_type}: {error_msg}")
             usage_holder = msg.get("usage", {})  ####
             if "choices" in msg:
                 ## Tease out ['choices'][0]...['delta'/'message']


### PR DESCRIPTION
- When using `stream`/`astream` with tool calling for models that do not support stream with tool calling, it should output: `{"error": {"object": "error", "message": "Tool calling is not supported in streaming mode!", "type": "BadRequestError", "param": null, "code": 400}}` in its streaming response, but LangChain NVIDIA currently ignores that error and instead returns empty chunk. This PR fixes the issue by catching error object in the streaming response.