### PR TITLE
Remove upper bound for a dependency

### DIFF
--- a/libs/ai-endpoints/poetry.lock
+++ b/libs/ai-endpoints/poetry.lock
@@ -2070,4 +2070,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "419d20214900aee6f0a889764f53e610704f5912455cb2ef7204be7d935b444d"
+content-hash = "ae1c4de5a798211b54391f0d5233c63a6415824dedc50268fa18e07be6f2e1fb"

--- a/libs/ai-endpoints/pyproject.toml
+++ b/libs/ai-endpoints/pyproject.toml
@@ -16,7 +16,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langchain-core = ">=0.3.51,<0.4"
+langchain-core = ">=0.3.51"
 aiohttp = "^3.9.1"
 filetype = "^1.2.0"
 


### PR DESCRIPTION
The "<0.4" upper bound prevents this package from being used with LangChain 1.0.
In my testing however, it seems compatible.
Remove this upper bound since it is anyway [discouraged](https://pip.pypa.io/en/latest/topics/dependency-resolution/#use-upper-bounds-sparingly) by pip developers.