### PR TITLE
ci: Upgrade CI Python version for LangChain NVIDIA AI Endpoints

### DIFF
--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -8,6 +8,16 @@ NVIDIA_DIRS = [
     "libs/trt",
 ]
 
+PYTHON_VERSIONS = {
+    "libs/ai-endpoints": ["3.10", "3.11", "3.12", "3.13"],
+    "libs/trt": ["3.8", "3.9", "3.10", "3.11"],
+}
+
+LINT_PYTHON_VERSIONS = {
+    "libs/ai-endpoints": ["3.10", "3.13"],
+    "libs/trt": ["3.8", "3.11"],
+}
+
 if __name__ == "__main__":
     files = sys.argv[1:]
 
@@ -48,11 +58,29 @@ if __name__ == "__main__":
         # elif any(file.startswith(p) for p in ["docs/", "templates/", "cookbook/"]):
         #     dirs_to_run["lint"].add(".")
 
+    test_matrix = [
+        {
+            "working-directory": dir_,
+            "python-versions": json.dumps(PYTHON_VERSIONS.get(dir_, ["3.8", "3.9", "3.10", "3.11"]))
+        }
+        for dir_ in dirs_to_run["test"]
+    ]
+    
+    lint_matrix = [
+        {
+            "working-directory": dir_,
+            "python-versions": json.dumps(LINT_PYTHON_VERSIONS.get(dir_, ["3.8", "3.11"]))
+        }
+        for dir_ in (dirs_to_run["lint"] | dirs_to_run["test"])
+    ]
+    
     outputs = {
         "dirs-to-lint": list(
             dirs_to_run["lint"] | dirs_to_run["test"]
         ),
         "dirs-to-test": list(dirs_to_run["test"]),
+        "test-matrix": test_matrix,
+        "lint-matrix": lint_matrix,
     }
     for key, value in outputs.items():
         json_output = json.dumps(value)

--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -7,6 +7,11 @@ on:
         required: true
         type: string
         description: "From which folder this pipeline executes"
+      python-versions:
+        required: false
+        type: string
+        default: '["3.8", "3.9", "3.10", "3.11"]'
+        description: "JSON array of Python versions to test"
 
 env:
   POETRY_VERSION: "1.7.1"
@@ -19,11 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
+        python-version: ${{ fromJson(inputs.python-versions) }}
     name: "poetry run pytest -m compile tests/integration_tests #${{ matrix.python-version }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -11,6 +11,11 @@ on:
         required: false
         type: string
         description: "Relative path to the langchain library folder"
+      python-versions:
+        required: false
+        type: string
+        default: '["3.8", "3.11"]'
+        description: "JSON array of Python versions to lint (should be min and max supported versions)"
 
 env:
   POETRY_VERSION: "1.7.1"
@@ -32,9 +37,7 @@ jobs:
         # GitHub rate-limits how many jobs can be running at any one time.
         # Starting new jobs is also relatively slow,
         # so linting on fewer versions makes CI faster.
-        python-version:
-          - "3.8"
-          - "3.11"
+        python-version: ${{ fromJson(inputs.python-versions) }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/_scheduled_test.yml
+++ b/.github/workflows/_scheduled_test.yml
@@ -16,12 +16,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.8"
-          - "3.11"
-        working-directory:
-          - "libs/ai-endpoints"
-          - "libs/trt"
+        include:
+          - python-version: "3.8"
+            working-directory: "libs/trt"
+          - python-version: "3.11"
+            working-directory: "libs/trt"
+          - python-version: "3.11"
+            working-directory: "libs/ai-endpoints"
+          - python-version: "3.13"
+            working-directory: "libs/ai-endpoints"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -11,6 +11,11 @@ on:
         required: false
         type: string
         description: "Relative path to the langchain library folder"
+      python-versions:
+        required: false
+        type: string
+        default: '["3.8", "3.9", "3.10", "3.11"]'
+        description: "JSON array of Python versions to test"
 
 env:
   POETRY_VERSION: "1.7.1"
@@ -23,11 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
+        python-version: ${{ fromJson(inputs.python-versions) }}
     name: "make test #${{ matrix.python-version }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -35,40 +35,45 @@ jobs:
     outputs:
       dirs-to-lint: ${{ steps.set-matrix.outputs.dirs-to-lint }}
       dirs-to-test: ${{ steps.set-matrix.outputs.dirs-to-test }}
+      test-matrix: ${{ steps.set-matrix.outputs.test-matrix }}
+      lint-matrix: ${{ steps.set-matrix.outputs.lint-matrix }}
   lint:
-    name: cd ${{ matrix.working-directory }}
+    name: cd ${{ matrix.config.working-directory }}
     needs: [ build ]
-    if: ${{ needs.build.outputs.dirs-to-lint != '[]' }}
+    if: ${{ needs.build.outputs.lint-matrix != '[]' }}
     strategy:
       matrix:
-        working-directory: ${{ fromJson(needs.build.outputs.dirs-to-lint) }}
+        config: ${{ fromJson(needs.build.outputs.lint-matrix) }}
     uses: ./.github/workflows/_lint.yml
     with:
-      working-directory: ${{ matrix.working-directory }}
+      working-directory: ${{ matrix.config.working-directory }}
+      python-versions: ${{ matrix.config.python-versions }}
     secrets: inherit
 
   test:
-    name: cd ${{ matrix.working-directory }}
+    name: cd ${{ matrix.config.working-directory }}
     needs: [ build ]
-    if: ${{ needs.build.outputs.dirs-to-test != '[]' }}
+    if: ${{ needs.build.outputs.test-matrix != '[]' }}
     strategy:
       matrix:
-        working-directory: ${{ fromJson(needs.build.outputs.dirs-to-test) }}
+        config: ${{ fromJson(needs.build.outputs.test-matrix) }}
     uses: ./.github/workflows/_test.yml
     with:
-      working-directory: ${{ matrix.working-directory }}
+      working-directory: ${{ matrix.config.working-directory }}
+      python-versions: ${{ matrix.config.python-versions }}
     secrets: inherit
 
   compile-integration-tests:
-    name: cd ${{ matrix.working-directory }}
+    name: cd ${{ matrix.config.working-directory }}
     needs: [ build ]
-    if: ${{ needs.build.outputs.dirs-to-test != '[]' }}
+    if: ${{ needs.build.outputs.test-matrix != '[]' }}
     strategy:
       matrix:
-        working-directory: ${{ fromJson(needs.build.outputs.dirs-to-test) }}
+        config: ${{ fromJson(needs.build.outputs.test-matrix) }}
     uses: ./.github/workflows/_compile_integration_test.yml
     with:
-      working-directory: ${{ matrix.working-directory }}
+      working-directory: ${{ matrix.config.working-directory }}
+      python-versions: ${{ matrix.config.python-versions }}
     secrets: inherit
   ci_success:
     name: "CI Success"

--- a/libs/ai-endpoints/poetry.lock
+++ b/libs/ai-endpoints/poetry.lock
@@ -173,7 +173,7 @@ description = "Timeout context manager for asyncio programs"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_version < \"3.11\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
     {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
@@ -432,7 +432,7 @@ description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "test"]
-markers = "python_version < \"3.11\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
     {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
@@ -940,59 +940,11 @@ files = [
 
 [[package]]
 name = "numpy"
-version = "1.26.4"
-description = "Fundamental package for array computing in Python"
-optional = false
-python-versions = ">=3.9"
-groups = ["test"]
-markers = "python_full_version < \"3.12.4\""
-files = [
-    {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
-    {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
-    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4"},
-    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"},
-    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a"},
-    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2"},
-    {file = "numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07"},
-    {file = "numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5"},
-    {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
-    {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
-    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e"},
-    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5"},
-    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a"},
-    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a"},
-    {file = "numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20"},
-    {file = "numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2"},
-    {file = "numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218"},
-    {file = "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b"},
-    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"},
-    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"},
-    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a"},
-    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0"},
-    {file = "numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110"},
-    {file = "numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818"},
-    {file = "numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c"},
-    {file = "numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be"},
-    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764"},
-    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3"},
-    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd"},
-    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c"},
-    {file = "numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6"},
-    {file = "numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea"},
-    {file = "numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30"},
-    {file = "numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c"},
-    {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
-    {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
-]
-
-[[package]]
-name = "numpy"
 version = "2.2.3"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["test"]
-markers = "python_full_version >= \"3.12.4\""
 files = [
     {file = "numpy-2.2.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cbc6472e01952d3d1b2772b720428f8b90e2deea8344e854df22b0618e9cce71"},
     {file = "numpy-2.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdfe0c22692a30cd830c0755746473ae66c4a8f2e7bd508b35fb3b6a0813d787"},
@@ -1721,7 +1673,7 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["test", "typing"]
-markers = "python_version < \"3.11\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -2069,5 +2021,5 @@ cffi = ["cffi (>=1.11)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9,<4.0"
-content-hash = "ae1c4de5a798211b54391f0d5233c63a6415824dedc50268fa18e07be6f2e1fb"
+python-versions = ">=3.10,<4.0"
+content-hash = "7fb4913142e25c6a6ab2f1f7fd53da4501e5c8e5693a05099afae59a5bb66a6d"

--- a/libs/ai-endpoints/pyproject.toml
+++ b/libs/ai-endpoints/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 "Source Code" = "https://github.com/langchain-ai/langchain-nvidia/tree/main/libs/ai-endpoints"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4.0"
+python = ">=3.10,<4.0"
 langchain-core = ">=0.3.51"
 aiohttp = "^3.9.1"
 filetype = "^1.2.0"


### PR DESCRIPTION
This PR updates the CI testing for LangChain NVIDIA AI Endpoints to test only Python 3.10 and above, aligning with the langchain-core v1.0 upgrade.

### Context
langchain-core v1.0 only supports Python >=3.10 ([migration guide](https://docs.langchain.com/oss/python/migrate/langchain-v1#dropped-python-3-9-support)), so we will delete the CI test for Python < 3.10.

### Changes
- Update CI test matrix for langchain-nvidia-ai-endpoints to test Python 3.10+ only
- Remove Python < 3.10 from CI test matrix for langchain-nvidia-ai-endpoints
- Keep langchain-nvidia-trt CI unchanged (Python 3.8.1+ support maintained)