### PR TITLE
fix: Deduplicate models from /v1/models API response

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -229,17 +229,13 @@ class _NVIDIAClient(BaseModel):
                     # we override the infer_path to use the custom endpoint
                     self.infer_path = model.endpoint
             else:
-                candidates = [
-                    model
+                candidates = {
+                    model.id: model
                     for model in self.available_models
                     if model.id == self.mdl_name
-                ]
-                assert len(candidates) <= 1, (
-                    f"Multiple candidates for {self.mdl_name} "
-                    f"in `available_models`: {candidates}"
-                )
-                if candidates:
-                    model = candidates[0]
+                }
+                if self.mdl_name in candidates:
+                    model = candidates[self.mdl_name]
                     warnings.warn(
                         f"Found {self.mdl_name} in available_models, but type is "
                         "unknown and inference may fail."
@@ -365,20 +361,24 @@ class _NVIDIAClient(BaseModel):
         # }
         assert response.status_code == 200, "Failed to get models"
         assert "data" in response.json(), "No data found in response"
-        self._available_models = []
+        seen: dict[str, Model] = {}
         for element in response.json()["data"]:
             assert "id" in element, f"No id found in {element}"
-            if not (model := determine_model(element["id"])):
+            model_id = element["id"]
+            if model_id in seen:
+                continue
+            if not (model := determine_model(model_id)):
                 # model is not in table of known models, but it exists
                 # so we'll let it through. use of this model will be
                 # accompanied by a warning.
-                model = Model(id=element["id"])
+                model = Model(id=model_id)
 
             # add base model for local-nim mode
             model.base_model = element.get("root")
 
-            self._available_models.append(model)
+            seen[model_id] = model
 
+        self._available_models = list(seen.values())
         return self._available_models
 
     def get_available_models(

--- a/libs/ai-endpoints/tests/unit_tests/test_available_models.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_available_models.py
@@ -1,7 +1,11 @@
+import re
 import warnings
 from typing import Any
 
-from langchain_nvidia_ai_endpoints import Model, register_model
+import requests_mock as rm
+
+from langchain_nvidia_ai_endpoints import ChatNVIDIA, Model, register_model
+from langchain_nvidia_ai_endpoints._common import _NVIDIAClient
 
 
 def test_model_listing(public_class: Any, mock_model: str) -> None:
@@ -29,3 +33,56 @@ def test_model_listing_hosted(
     register_model(model)
     models = public_class.get_available_models()
     assert any(model.id == mock_model for model in models)
+
+
+def test_duplicate_models_in_api_response(
+    requests_mock: rm.Mocker,
+) -> None:
+    """API returning duplicate model entries should not crash ChatNVIDIA.
+
+    Regression test for the case where /v1/models returns the same model id
+    more than once (e.g. nvidia/nemotron-3-super-120b-a12b). Previously this
+    triggered an AssertionError in _NVIDIAClient.__init__.
+    """
+    duplicate_model = "test-org/duplicate-model"
+    requests_mock.get(
+        re.compile(".*/v1/models"),
+        json={
+            "data": [
+                {"id": duplicate_model},
+                {"id": duplicate_model},
+                {"id": "test-org/unique-model"},
+            ]
+        },
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        client = ChatNVIDIA(model=duplicate_model)
+    assert client.model == duplicate_model
+
+
+def test_duplicate_models_deduplicated_in_available_models(
+    requests_mock: rm.Mocker,
+) -> None:
+    """available_models should contain each model id exactly once."""
+    duplicate_model = "test-org/duplicate-model"
+    requests_mock.get(
+        re.compile(".*/v1/models"),
+        json={
+            "data": [
+                {"id": duplicate_model},
+                {"id": duplicate_model},
+                {"id": "test-org/unique-model"},
+            ]
+        },
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        client = ChatNVIDIA(model=duplicate_model)
+    # Access the internal client's cached model list (API-only, before
+    # get_available_models merges in the static MODEL_TABLE)
+    internal: _NVIDIAClient = client._client  # type: ignore[attr-defined]
+    ids = [m.id for m in internal.available_models]
+    assert ids.count(duplicate_model) == 1
+    assert ids.count("test-org/unique-model") == 1
+    assert len(ids) == 2


### PR DESCRIPTION
## Problem

ChatNVIDIA crashes with an AssertionError when instantiated with a model that is not in the static MODEL_TABLE and appears more than once in the NIM /v1/models API response.

The NIM API at integrate.api.nvidia.com/v1/models currently returns duplicate entries for some models (e.g. nvidia/nemotron-3-super-120b-a12b). The available_models property stores every entry without deduplication, and __init__ asserts at most one candidate match:

```
assert len(candidates) <= 1  # crashes with 2 identical entries
```

Any model in the static MODEL_TABLE is unaffected — determine_model() resolves it before the API is ever queried.

## Fix

Two changes in _common.py, both in _NVIDIAClient:

1. available_models property — Deduplicate at the source using a seen dict keyed by model ID. Duplicate API entries are skipped on insert. All downstream callers (__init__, get_available_models, etc.) receive a clean list.
2. __init__ candidate lookup — Replace the list comprehension + assert with a dict comprehension that naturally deduplicates by key. This is a belt-and-suspenders measure in case duplicates arrive through a different path.

Both changes preserve existing behavior for all non-duplicate cases. No public API changes.

## Tests

Two regression tests added to test_available_models.py:

- test_duplicate_models_in_api_response — ChatNVIDIA(model=...) no longer crashes when /v1/models returns the same model ID twice
- test_duplicate_models_deduplicated_in_available_models — The internal _available_models list contains each ID exactly once after dedup