### PR TITLE
fix: xfail unsupported thinking-mode case on self-hosted NIM

### DIFF
--- a/libs/ai-endpoints/tests/integration_tests/test_thinking_mode.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_thinking_mode.py
@@ -136,7 +136,13 @@ async def test_thinking_mode_unsupported_model(
 ) -> None:
     """Test that thinking mode is handled gracefully for unsupported models."""
     unsupported_model = "meta/llama3-8b-instruct"
-    llm = ChatNVIDIA(model=unsupported_model, **mode).with_thinking_mode(enabled=True)
+    base_llm = ChatNVIDIA(model=unsupported_model, **mode)
+    if not base_llm._client.is_hosted:
+        pytest.xfail(
+            "Downloadable/local NIM may not host the hardcoded unsupported model "
+            "`meta/llama3-8b-instruct` and can return 404."
+        )
+    llm = base_llm.with_thinking_mode(enabled=True)
 
     if is_async_func(func):
         response = await func(llm, "What is 2+2?")


### PR DESCRIPTION
Use ChatNVIDIA client hosted detection (`_client.is_hosted`) in thinking-mode integration tests and mark unsupported-model cases as xfail for downloadable/self-hosted NIMs, where the hardcoded model may return 404.