### PR TITLE
feat: Support reranking VLM

### DIFF
--- a/libs/ai-endpoints/README.md
+++ b/libs/ai-endpoints/README.md
@@ -337,6 +337,33 @@ response = client.compress_documents(
 print(f"Most relevant: {response[0].page_content}\nLeast relevant: {response[-1].page_content}")
 ```
 
+### Ranking with a Vision-Language Rerank Model
+
+`NVIDIARerank` can also rerank documents that carry an image alongside their text using a ranking VLM such as
+[nvidia/llama-nemotron-rerank-vl-1b-v2](https://build.nvidia.com/nvidia/llama-nemotron-rerank-vl-1b-v2).
+
+The following example connects to a ranking VLM.
+
+```python
+from langchain_nvidia_ai_endpoints import NVIDIARerank
+from langchain_core.documents import Document
+
+query = "Show me a picture of a cat"
+documents = [
+    Document(
+        page_content="The picture of a cat.",
+        metadata={"image": "/path/to/image"},
+    ),
+    Document(
+        page_content="",
+        metadata={"image": "/path/to/image"},
+    ),
+    Document(page_content="The weather today is sunny."),
+]
+
+ranker = NVIDIARerank(model="nvidia/llama-nemotron-rerank-vl-1b-v2")
+response = ranker.compress_documents(query=query, documents=documents)
+```
 
 ### Retrieval
 

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -47,7 +47,16 @@ class Model(BaseModel):
 
     # why do we have a model_type? because ChatNVIDIA can speak both chat and vlm.
     model_type: Optional[
-        Literal["chat", "vlm", "nv-vlm", "embedding", "ranking", "completions", "qa"]
+        Literal[
+            "chat",
+            "vlm",
+            "nv-vlm",
+            "embedding",
+            "ranking",
+            "ranking-vlm",
+            "completions",
+            "qa",
+        ]
     ] = None
 
     client: Optional[
@@ -83,7 +92,7 @@ class Model(BaseModel):
             supported = {
                 "ChatNVIDIA": ("chat", "vlm", "nv-vlm", "qa"),
                 "NVIDIAEmbeddings": ("embedding",),
-                "NVIDIARerank": ("ranking",),
+                "NVIDIARerank": ("ranking", "ranking-vlm"),
                 "NVIDIA": ("completions",),
             }
             if self.model_type not in supported.get(self.client, ()):
@@ -1000,6 +1009,15 @@ RANKING_MODEL_TABLE = {
     ),
 }
 
+RANKING_VLM_MODEL_TABLE = {
+    "nvidia/llama-nemotron-rerank-vl-1b-v2": Model(
+        id="nvidia/llama-nemotron-rerank-vl-1b-v2",
+        model_type="ranking-vlm",
+        client="NVIDIARerank",
+        endpoint="https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-vl-1b-v2/reranking",
+    ),
+}
+
 COMPLETION_MODEL_TABLE = {
     "bigcode/starcoder2-7b": Model(
         id="bigcode/starcoder2-7b",
@@ -1031,6 +1049,7 @@ MODEL_TABLE = {
     **VLM_MODEL_TABLE,
     **EMBEDDING_MODEL_TABLE,
     **RANKING_MODEL_TABLE,
+    **RANKING_VLM_MODEL_TABLE,
     **COMPLETION_MODEL_TABLE,
 }
 

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_utils.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_utils.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import base64
+import logging
+import os
+import urllib.parse
 from typing import (
     Any,
     Dict,
@@ -14,6 +18,40 @@ from langchain_core.messages import (
     SystemMessage,
     ToolMessage,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _is_url(s: str) -> bool:
+    try:
+        result = urllib.parse.urlparse(s)
+        return all([result.scheme, result.netloc])
+    except Exception as e:
+        logger.debug(f"Unable to parse URL: {e}")
+        return False
+
+
+def _url_to_b64_string(image_source: str) -> str:
+    try:
+        if _is_url(image_source):
+            return image_source
+        elif image_source.startswith("data:image"):
+            return image_source
+        elif os.path.exists(image_source):
+            with open(image_source, "rb") as f:
+                image_data = f.read()
+                import filetype  # type: ignore
+
+                kind = filetype.guess(image_data)
+                image_type = kind.extension if kind else "unknown"
+                encoded = base64.b64encode(image_data).decode("utf-8")
+                return f"data:image/{image_type};base64,{encoded}"
+        else:
+            raise ValueError(
+                "The provided string is not a valid URL, base64, or file path."
+            )
+    except Exception as e:
+        raise ValueError(f"Unable to process the provided image source: {e}")
 
 
 def _normalize_content(content: Any) -> Any:

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import base64
 import enum
 import json
 import logging
-import os
 import re
-import urllib.parse
 import warnings
 from typing import (
     Any,
@@ -65,7 +62,10 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 from langchain_nvidia_ai_endpoints._common import _NVIDIAClient
 from langchain_nvidia_ai_endpoints._statics import Model
-from langchain_nvidia_ai_endpoints._utils import convert_message_to_dict
+from langchain_nvidia_ai_endpoints._utils import (
+    _url_to_b64_string,
+    convert_message_to_dict,
+)
 from langchain_nvidia_ai_endpoints.data._profiles import _PROFILES
 
 # Type variable for generic parser types
@@ -82,74 +82,6 @@ def _get_default_model_profile(model_name: str) -> ModelProfile:
     """Fetch profile from registry; return empty dict if not found."""
     default = _MODEL_PROFILES.get(model_name) or {}
     return default.copy()
-
-
-def _is_url(s: str) -> bool:
-    try:
-        result = urllib.parse.urlparse(s)
-        return all([result.scheme, result.netloc])
-    except Exception as e:
-        logger.debug(f"Unable to parse URL: {e}")
-        return False
-
-
-def _url_to_b64_string(image_source: str) -> str:
-    try:
-        if _is_url(image_source):
-            return image_source
-            # import sys
-            # import io
-            # try:
-            #     import PIL.Image
-            #     has_pillow = True
-            # except ImportError:
-            #     has_pillow = False
-            # def _resize_image(img_data: bytes, max_dim: int = 1024) -> str:
-            #     if not has_pillow:
-            #         print(  # noqa: T201
-            #             "Pillow is required to resize images down to reasonable scale."  # noqa: E501
-            #             " Please install it using `pip install pillow`."
-            #             " For now, not resizing; may cause NVIDIA API to fail."
-            #         )
-            #         return base64.b64encode(img_data).decode("utf-8")
-            #     image = PIL.Image.open(io.BytesIO(img_data))
-            #     max_dim_size = max(image.size)
-            #     aspect_ratio = max_dim / max_dim_size
-            #     new_h = int(image.size[1] * aspect_ratio)
-            #     new_w = int(image.size[0] * aspect_ratio)
-            #     resized_image = image.resize((new_w, new_h), PIL.Image.Resampling.LANCZOS)  # noqa: E501
-            #     output_buffer = io.BytesIO()
-            #     resized_image.save(output_buffer, format="JPEG")
-            #     output_buffer.seek(0)
-            #     resized_b64_string = base64.b64encode(output_buffer.read()).decode("utf-8")  # noqa: E501
-            #     return resized_b64_string
-            # b64_template = "data:image/png;base64,{b64_string}"
-            # response = requests.get(
-            #     image_source, headers={"User-Agent": "langchain-nvidia-ai-endpoints"}
-            # )
-            # response.raise_for_status()
-            # encoded = base64.b64encode(response.content).decode("utf-8")
-            # if sys.getsizeof(encoded) > 200000:
-            #     ## (VK) Temporary fix. NVIDIA API has a limit of 250KB for the input.
-            #     encoded = _resize_image(response.content)
-            # return b64_template.format(b64_string=encoded)
-        elif image_source.startswith("data:image"):
-            return image_source
-        elif os.path.exists(image_source):
-            with open(image_source, "rb") as f:
-                image_data = f.read()
-                import filetype  # type: ignore
-
-                kind = filetype.guess(image_data)
-                image_type = kind.extension if kind else "unknown"
-                encoded = base64.b64encode(image_data).decode("utf-8")
-                return f"data:image/{image_type};base64,{encoded}"
-        else:
-            raise ValueError(
-                "The provided string is not a valid URL, base64, or file path."
-            )
-    except Exception as e:
-        raise ValueError(f"Unable to process the provided image source: {e}")
 
 
 def _deep_merge(base: dict, update: dict) -> dict:

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
@@ -153,6 +153,33 @@ class NVIDIARerank(BaseDocumentCompressor):
             # memory bandwidth at over 2 terabytes per second (TB/s) to run the largest
             # models and datasets.
             ```
+
+        Ranking with a Vision-Language Rerank Model:
+            `NVIDIARerank` can also rerank documents that carry an image
+            alongside their text using a ranking VLM such as
+            ``nvidia/llama-nemotron-rerank-vl-1b-v2``.
+
+
+            ```python
+            from langchain_nvidia_ai_endpoints import NVIDIARerank
+            from langchain_core.documents import Document
+
+            query = "Show me a picture of a cat"
+            documents = [
+                Document(
+                    page_content="The picture of a cat.",
+                    metadata={"image": "/path/to/image"},
+                ),
+                Document(
+                    page_content="",
+                    metadata={"image": "/path/to/image"},
+                ),
+                Document(page_content="The weather today is sunny."),
+            ]
+
+            ranker = NVIDIARerank(model="nvidia/llama-nemotron-rerank-vl-1b-v2")
+            response = ranker.compress_documents(query=query, documents=documents)
+            ```
         """
 
         super().__init__(**kwargs)

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
@@ -16,6 +16,7 @@ from pydantic import (
 
 from langchain_nvidia_ai_endpoints._common import _NVIDIAClient
 from langchain_nvidia_ai_endpoints._statics import Model
+from langchain_nvidia_ai_endpoints._utils import _url_to_b64_string
 
 
 class Ranking(BaseModel):
@@ -24,6 +25,7 @@ class Ranking(BaseModel):
 
 
 _DEFAULT_MODEL_NAME: str = "nvidia/llama-3.2-nv-rerankqa-1b-v2"
+_DEFAULT_VLM_MODEL_NAME: str = "nvidia/llama-nemotron-rerank-vl-1b-v2"
 _DEFAULT_BATCH_SIZE: int = 32
 
 
@@ -205,20 +207,42 @@ class NVIDIARerank(BaseDocumentCompressor):
         """Get a list of available models that work with `NVIDIARerank`."""
         return cls(**kwargs).available_models
 
-    def _prepare_payload(self, documents: List[str], query: str) -> Dict[str, Any]:
+    def _prepare_payload(self, documents: List[Document], query: str) -> Dict[str, Any]:
         """Prepare payload for both sync and async methods.
 
         Args:
-            documents: List of document texts to rank
+            documents: List of documents to rank
             query: Query text
 
         Returns:
             Payload dictionary
         """
-        payload = {
+        passages = []
+        has_image = False
+        for doc in documents:
+            passage: Dict[str, Any] = {"text": doc.page_content}
+            if image := doc.metadata.get("image"):
+                passage["image"] = _url_to_b64_string(image)
+                has_image = True
+            passages.append(passage)
+
+        if has_image:
+            model_info = getattr(self._client, "model", None)
+            model_type = getattr(model_info, "model_type", None)
+            if model_type and model_type != "ranking-vlm":
+                warnings.warn(
+                    (
+                        f"Passage image metadata was supplied, but the "
+                        f"reranking model '{self.model}' is not known to "
+                        f"support image inputs."
+                    ),
+                    UserWarning,
+                )
+
+        payload: Dict[str, Any] = {
             "model": self.model,
             "query": {"text": query},
-            "passages": [{"text": passage} for passage in documents],
+            "passages": passages,
         }
         if self.truncate:
             payload["truncate"] = self.truncate
@@ -282,7 +306,7 @@ class NVIDIARerank(BaseDocumentCompressor):
         results.sort(key=lambda x: x.metadata["relevance_score"], reverse=True)
 
     # todo: batching when len(documents) > endpoint's max batch size
-    def _rank(self, documents: List[str], query: str) -> List[Ranking]:
+    def _rank(self, documents: List[Document], query: str) -> List[Ranking]:
         payload = self._prepare_payload(documents, query)
         response = self._client.get_req(
             payload=payload, extra_headers=self.default_headers
@@ -315,9 +339,7 @@ class NVIDIARerank(BaseDocumentCompressor):
         doc_list = list(documents)
         results: List[Document] = []
         for doc_batch in self._batch(doc_list, self.max_batch_size):
-            rankings = self._rank(
-                query=query, documents=[d.page_content for d in doc_batch]
-            )
+            rankings = self._rank(query=query, documents=doc_batch)
             self._process_batch_rankings(doc_batch, rankings, results)
 
         # if we batched, we need to sort the results
@@ -326,7 +348,7 @@ class NVIDIARerank(BaseDocumentCompressor):
 
         return results[: self.top_n]
 
-    async def _arank(self, documents: List[str], query: str) -> List[Ranking]:
+    async def _arank(self, documents: List[Document], query: str) -> List[Ranking]:
         """Async version of _rank."""
         payload = self._prepare_payload(documents, query)
         response_text = await self._client.aget_req(
@@ -348,9 +370,7 @@ class NVIDIARerank(BaseDocumentCompressor):
         doc_list = list(documents)
         results: List[Document] = []
         for doc_batch in self._batch(doc_list, self.max_batch_size):
-            rankings = await self._arank(
-                query=query, documents=[d.page_content for d in doc_batch]
-            )
+            rankings = await self._arank(query=query, documents=doc_batch)
             self._process_batch_rankings(doc_batch, rankings, results)
 
         # if we batched, we need to sort the results

--- a/libs/ai-endpoints/tests/integration_tests/conftest.py
+++ b/libs/ai-endpoints/tests/integration_tests/conftest.py
@@ -9,7 +9,11 @@ from langchain_nvidia_ai_endpoints import (
     NVIDIAEmbeddings,
     NVIDIARerank,
 )
-from langchain_nvidia_ai_endpoints._statics import MODEL_TABLE, Model
+from langchain_nvidia_ai_endpoints._statics import (
+    MODEL_TABLE,
+    RANKING_VLM_MODEL_TABLE,
+    Model,
+)
 from langchain_nvidia_ai_endpoints.chat_models import (
     _DEFAULT_MODEL_NAME as DEFAULT_CHAT_MODEL,
 )
@@ -36,6 +40,9 @@ from langchain_nvidia_ai_endpoints.llm import (
 )
 from langchain_nvidia_ai_endpoints.reranking import (
     _DEFAULT_MODEL_NAME as DEFAULT_RERANKING_MODEL,
+)
+from langchain_nvidia_ai_endpoints.reranking import (
+    _DEFAULT_VLM_MODEL_NAME as DEFAULT_RERANKING_VLM_MODEL,
 )
 
 
@@ -100,6 +107,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store",
         nargs="+",
         help="Run tests for a specific rerank model or list of models",
+    )
+    parser.addoption(
+        "--rerank-vlm-model-id",
+        action="store",
+        nargs="+",
+        help="Run tests for a specific rerank VLM model or list of models",
     )
     parser.addoption(
         "--vlm-model-id",
@@ -198,6 +211,14 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         if metafunc.config.getoption("all_models"):
             models = [model.id for model in NVIDIARerank(**mode).available_models]
         metafunc.parametrize("rerank_model", models, ids=models)
+
+    if "rerank_vlm_model" in metafunc.fixturenames:
+        models = [DEFAULT_RERANKING_VLM_MODEL]
+        if model_list := metafunc.config.getoption("rerank_vlm_model_id"):
+            models = model_list
+        if metafunc.config.getoption("all_models"):
+            models = list(RANKING_VLM_MODEL_TABLE.keys())
+        metafunc.parametrize("rerank_vlm_model", models, ids=models)
 
     if "vlm_model" in metafunc.fixturenames:
         models = [DEFAULT_VLM_MODEL]

--- a/libs/ai-endpoints/tests/integration_tests/test_ranking_vlm.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_ranking_vlm.py
@@ -1,0 +1,84 @@
+import base64
+
+import pytest
+from langchain_core.documents import Document
+
+from langchain_nvidia_ai_endpoints import NVIDIARerank
+
+
+@pytest.mark.parametrize(
+    "img",
+    [
+        "tests/data/nvidia-picasso.jpg",
+        "tests/data/nvidia-picasso.png",
+        "tests/data/nvidia-picasso.webp",
+        "tests/data/nvidia-picasso.gif",
+        f"""data:image/jpg;base64,{
+            base64.b64encode(
+                open('tests/data/nvidia-picasso.jpg', 'rb').read()
+            ).decode('utf-8')
+        }""",
+    ],
+    ids=["jpg", "png", "webp", "gif", "data"],
+)
+@pytest.mark.parametrize(
+    "func", ["compress", "acompress"], ids=["compress", "acompress"]
+)
+@pytest.mark.asyncio
+async def test_vlm_reranker_image_type(
+    rerank_vlm_model: str, mode: dict, func: str, img: str
+) -> None:
+    ranker = NVIDIARerank(model=rerank_vlm_model, **mode)
+    documents = [
+        Document(
+            page_content="A colorful cat with a frog and Times Square.",
+            metadata={"image": img},
+        ),
+        Document(page_content="The weather today is sunny."),
+    ]
+    query = "Show me a picture of a cat or a frog"
+    if func == "compress":
+        results = ranker.compress_documents(documents=documents, query=query)
+    else:
+        results = await ranker.acompress_documents(documents=documents, query=query)
+    assert len(results) > 0
+    for doc in results:
+        assert "relevance_score" in doc.metadata
+        assert isinstance(doc.metadata["relevance_score"], float)
+
+
+@pytest.mark.parametrize(
+    "img",
+    [
+        "tests/data/nvidia-picasso.jpg",
+        "tests/data/nvidia-picasso.png",
+        "tests/data/nvidia-picasso.webp",
+        "tests/data/nvidia-picasso.gif",
+    ],
+    ids=["jpg", "png", "webp", "gif"],
+)
+@pytest.mark.parametrize(
+    "func", ["compress", "acompress"], ids=["compress", "acompress"]
+)
+@pytest.mark.asyncio
+async def test_vlm_reranker_image_only(
+    rerank_vlm_model: str, mode: dict, func: str, img: str
+) -> None:
+    """VLM reranker should work with image-only passages (empty text)."""
+    ranker = NVIDIARerank(model=rerank_vlm_model, **mode)
+    documents = [
+        Document(
+            page_content="",
+            metadata={"image": img},
+        ),
+        Document(page_content="The weather today is sunny."),
+    ]
+    query = "Show me a picture of a cat or a frog"
+    if func == "compress":
+        results = ranker.compress_documents(documents=documents, query=query)
+    else:
+        results = await ranker.acompress_documents(documents=documents, query=query)
+    assert len(results) > 0
+    for doc in results:
+        assert "relevance_score" in doc.metadata
+        assert isinstance(doc.metadata["relevance_score"], float)

--- a/libs/ai-endpoints/tests/unit_tests/test_ranking.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_ranking.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import pytest
 from langchain_core.documents import Document
@@ -185,3 +185,150 @@ async def test_extra_headers(
         )
         assert requests_mock.last_request is not None
         assert requests_mock.last_request.headers["X-Test"] == "test"
+
+
+def _get_passages(requests_mock: Mocker) -> List[Dict[str, Any]]:
+    """Helper to extract passages from the last sync request payload."""
+    assert requests_mock.last_request is not None
+    return requests_mock.last_request.json()["passages"]
+
+
+def test_text_only_payload_has_no_image_key(requests_mock: Mocker) -> None:
+    """Text-only documents should produce passages with only a 'text' key."""
+    warnings.filterwarnings("ignore", ".*Found mock-model in available_models.*")
+    client = NVIDIARerank(api_key="BOGUS", model="mock-model")
+    client.compress_documents(
+        documents=[
+            Document(page_content="first passage"),
+            Document(page_content="second passage"),
+        ],
+        query="test query",
+    )
+    passages = _get_passages(requests_mock)
+    assert len(passages) == 2
+    for p in passages:
+        assert "text" in p
+        assert "image" not in p
+    assert passages[0]["text"] == "first passage"
+    assert passages[1]["text"] == "second passage"
+
+
+def test_text_and_image_payload(requests_mock: Mocker) -> None:
+    """Documents with image metadata should include an 'image' field in the payload."""
+    warnings.filterwarnings("ignore", ".*Found mock-model in available_models.*")
+    client = NVIDIARerank(api_key="BOGUS", model="mock-model")
+    b64_image = "data:image/jpeg;base64,1234567abc"
+    client.compress_documents(
+        documents=[
+            Document(page_content="a caption", metadata={"image": b64_image}),
+        ],
+        query="test query",
+    )
+    passages = _get_passages(requests_mock)
+    assert len(passages) == 1
+    assert passages[0]["text"] == "a caption"
+    assert passages[0]["image"] == b64_image
+
+
+def test_image_only_payload(requests_mock: Mocker) -> None:
+    """Documents with empty text and image metadata should still work."""
+    warnings.filterwarnings("ignore", ".*Found mock-model in available_models.*")
+    client = NVIDIARerank(api_key="BOGUS", model="mock-model")
+    b64_image = "data:image/png;base64,1234567abc"
+    client.compress_documents(
+        documents=[
+            Document(page_content="", metadata={"image": b64_image}),
+        ],
+        query="test query",
+    )
+    passages = _get_passages(requests_mock)
+    assert len(passages) == 1
+    assert passages[0]["text"] == ""
+    assert passages[0]["image"] == b64_image
+
+
+def test_invalid_image_raises(requests_mock: Mocker) -> None:
+    """A bogus metadata['image'] value should raise ValueError."""
+    warnings.filterwarnings("ignore", ".*Found mock-model in available_models.*")
+    client = NVIDIARerank(api_key="BOGUS", model="mock-model")
+    with pytest.raises(ValueError):
+        client.compress_documents(
+            documents=[
+                Document(
+                    page_content="test passage",
+                    metadata={"image": "an image"},
+                ),
+            ],
+            query="test query",
+        )
+
+
+def test_image_on_non_vlm_model_warns(requests_mock: Mocker) -> None:
+    """Image metadata on a non-VLM ranking model should emit a UserWarning."""
+    warnings.filterwarnings("ignore", ".*Found mock-model in available_models.*")
+    client = NVIDIARerank(api_key="BOGUS", model="mock-model")
+    # Simulate a resolved text-only ranking model
+    assert client._client.model is not None
+    client._client.model.model_type = "ranking"
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        client.compress_documents(
+            documents=[
+                Document(
+                    page_content="test passage",
+                    metadata={"image": "data:image/png;base64,1234567abc"},
+                ),
+            ],
+            query="test query",
+        )
+    assert any(
+        "not known to support image" in str(warning.message) for warning in w
+    ), "expected a warning about image support"
+
+
+def test_image_on_ranking_vlm_model_no_warning(requests_mock: Mocker) -> None:
+    """Image metadata on a ranking-vlm model should not emit the guardrail warning."""
+    warnings.filterwarnings("ignore", ".*Found mock-model in available_models.*")
+    client = NVIDIARerank(api_key="BOGUS", model="mock-model")
+    assert client._client.model is not None
+    client._client.model.model_type = "ranking-vlm"
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        client.compress_documents(
+            documents=[
+                Document(
+                    page_content="test passage",
+                    metadata={"image": "data:image/png;base64,1234567abc"},
+                ),
+            ],
+            query="test query",
+        )
+    assert not any(
+        "not known to support image" in str(warning.message) for warning in w
+    )
+
+
+def test_mixed_text_and_image_payload(requests_mock: Mocker) -> None:
+    """A batch with both text-only and text+image docs produces correct payloads."""
+    warnings.filterwarnings("ignore", ".*Found mock-model in available_models.*")
+    client = NVIDIARerank(api_key="BOGUS", model="mock-model")
+    b64_image = "data:image/jpeg;base64,1234567abc"
+    client.compress_documents(
+        documents=[
+            Document(page_content="text only"),
+            Document(page_content="with image", metadata={"image": b64_image}),
+            Document(page_content="another text only"),
+        ],
+        query="test query",
+    )
+    passages = _get_passages(requests_mock)
+    assert len(passages) == 3
+    # first: text-only
+    assert passages[0]["text"] == "text only"
+    assert "image" not in passages[0]
+    # second: text+image
+    assert passages[1]["text"] == "with image"
+    assert passages[1]["image"] == b64_image
+    # third: text-only
+    assert passages[2]["text"] == "another text only"
+    assert "image" not in passages[2]


### PR DESCRIPTION
 - Add support for reranking VLMs via `NVIDIARerank`, allowing documents with image metadata to be reranked alongside text         
- Register [nvidia/llama-nemotron-rerank-vl-1b-v2](https://build.nvidia.com/nvidia/llama-nemotron-rerank-vl-1b-v2) as the first ranking-vlm model in a new `RANKING_VLM_MODEL_TABLE`                                                                
- Refactor `_url_to_b64_string` and `_is_url ` from `chat_models.py` into shared `_utils.py` for reuse by the reranker