### PR TITLE
refactor: split `_NVIDIAClient` into sync and async clients

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -42,7 +42,7 @@ _API_KEY_VAR = "NVIDIA_API_KEY"
 _BASE_URL_VAR = "NVIDIA_BASE_URL"
 
 
-class _NVIDIAClient(BaseModel):
+class _NVIDIAClientBase(BaseModel):
     """Low level client library interface to NIM endpoints."""
 
     default_hosted_model_name: str = Field(..., description="Default model name to use")
@@ -82,8 +82,6 @@ class _NVIDIAClient(BaseModel):
     )
 
     get_session_fn: Callable = Field(requests.Session)
-
-    get_async_session_fn: Callable = Field(aiohttp.ClientSession)
 
     verify_ssl: Union[bool, str] = Field(
         True,
@@ -191,12 +189,15 @@ class _NVIDIAClient(BaseModel):
 
         return v
 
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        # Create session function that sets verify parameter
+        self.get_session_fn = self._create_session
+
     # final validation after model is constructed
     # todo: when pydantic v2 is available,
     #       use __post_init__ or model_validator(method="after")
-    def __init__(self, **kwargs: Any):
-        super().__init__(**kwargs)
-
+    def _finalize(self) -> None:
         self.is_hosted = urlparse(self.base_url).netloc in [
             "integrate.api.nvidia.com",
             "ai.api.nvidia.com",
@@ -273,29 +274,11 @@ class _NVIDIAClient(BaseModel):
             else:
                 self.model = determine_model(self.mdl_name)
 
-        # Create session function that sets verify parameter
-        self.get_session_fn = self._create_session
-        self.get_async_session_fn = self._create_async_session
-
-    def _build_ssl_context(self) -> Union[bool, ssl.SSLContext]:
-        """Build an SSL context for aiohttp based on `verify_ssl` setting."""
-        if isinstance(self.verify_ssl, bool):
-            return self.verify_ssl
-        if isinstance(self.verify_ssl, str):
-            context = ssl.create_default_context(cafile=self.verify_ssl)
-            return context
-        return True
-
     def _create_session(self) -> requests.Session:
         """Create a session with SSL verification."""
         session = requests.Session()
         session.verify = self.verify_ssl
         return session
-
-    def _create_async_session(self) -> "aiohttp.ClientSession":
-        """Create an aiohttp session with SSL verification via connector."""
-        connector = aiohttp.TCPConnector(ssl=self._build_ssl_context())
-        return aiohttp.ClientSession(connector=connector)
 
     ###################################################################################
     ################### LangChain functions ###########################################
@@ -328,7 +311,7 @@ class _NVIDIAClient(BaseModel):
     ###################################################################################
     ################### Authorization handling ########################################
 
-    def __add_authorization(self, payload: dict) -> dict:
+    def _add_authorization(self, payload: dict) -> dict:
         if self.api_key:
             payload = {**payload}
             payload["headers"] = {
@@ -422,7 +405,7 @@ class _NVIDIAClient(BaseModel):
         }
         session = self.get_session_fn()
         self.last_response = response = session.post(
-            **self.__add_authorization(self.last_inputs)
+            **self._add_authorization(self.last_inputs)
         )
         self._try_raise(response)
         return response, session
@@ -438,7 +421,7 @@ class _NVIDIAClient(BaseModel):
         }
         session = self.get_session_fn()
         self.last_response = response = session.get(
-            **self.__add_authorization(self.last_inputs)
+            **self._add_authorization(self.last_inputs)
         )
         self._try_raise(response)
         return response, session
@@ -471,7 +454,7 @@ class _NVIDIAClient(BaseModel):
                 "headers": self.headers_tmpl["call"],
             }
             self.last_response = response = session.get(
-                **self.__add_authorization(payload)
+                **self._add_authorization(payload)
             )
         self._try_raise(response)
         return response
@@ -523,140 +506,6 @@ class _NVIDIAClient(BaseModel):
             message = self._format_error(rd)
             # todo: raise as an HTTPError
             raise Exception(message) from None
-
-    async def _post_async(
-        self,
-        invoke_url: str,
-        payload: Optional[dict] = {},
-        extra_headers: dict = {},
-    ) -> Tuple[aiohttp.ClientResponse, aiohttp.ClientSession]:
-        """Async version of `_post`"""
-        self.last_inputs = {
-            "url": invoke_url,
-            "headers": {
-                **self.headers_tmpl["call"],
-                **extra_headers,
-            },
-            "json": payload,
-        }
-        session = self.get_async_session_fn()
-        try:
-            self.last_response = response = await session.post(
-                **self.__add_authorization(self.last_inputs)
-            )
-            await self._try_raise_async(response)
-            return response, session
-        except:
-            await session.close()
-            raise
-
-    async def _get_async(
-        self,
-        invoke_url: str,
-    ) -> Tuple[aiohttp.ClientResponse, aiohttp.ClientSession]:
-        """Async version of `_get`"""
-        self.last_inputs = {
-            "url": invoke_url,
-            "headers": self.headers_tmpl["call"],
-        }
-        session = self.get_async_session_fn()
-        try:
-            self.last_response = response = await session.get(
-                **self.__add_authorization(self.last_inputs)
-            )
-            await self._try_raise_async(response)
-            return response, session
-        except:
-            await session.close()
-            raise
-
-    async def _wait_async(
-        self,
-        response: aiohttp.ClientResponse,
-        session: aiohttp.ClientSession,
-    ) -> aiohttp.ClientResponse:
-        """Async version of `_wait`"""
-        loop = asyncio.get_event_loop()
-        start_time = loop.time()
-        # note: the local NIM does not return a 202 status code
-        #       (per RL 22may2024 circa 24.05)
-        while response.status == 202:
-            await asyncio.sleep(self.interval)
-            if (loop.time() - start_time) > self.timeout:
-                raise TimeoutError(
-                    f"Timeout reached without a successful response."
-                    f"\nLast response: {str(response)}"
-                )
-            assert (
-                "NVCF-REQID" in response.headers
-            ), "Received 202 response with no request id to follow"
-            request_id = response.headers.get("NVCF-REQID")
-            payload = {
-                "url": self.polling_url_tmpl.format(request_id=request_id),
-                "headers": self.headers_tmpl["call"],
-            }
-            self.last_response = response = await session.get(
-                **self.__add_authorization(payload)
-            )
-        await self._try_raise_async(response)
-        return response
-
-    async def _try_raise_async(self, response: aiohttp.ClientResponse) -> None:
-        """Async version of `_try_raise` for `aiohttp` responses."""
-        # todo: Add unit tests for _try_raise_async and _try_raise
-        if response.status < 400:
-            return
-
-        # Read error body before session closes
-        try:
-            body_content = await response.read()
-            # Cache response body content in an additional _cached_content attribute
-            # as aiohttp.ClientResponse can only be read once. This allows tests and
-            # debugging tools to access the error response after it has been consumed
-            # by the _try_raise_async method.
-            response._cached_content = body_content  # type: ignore[attr-defined]
-        except Exception as e:
-            rd = {
-                "status": response.status,
-                "reason": response.reason,
-                "detail": f"Failed to read response body: {e}",
-            }
-            raise Exception(self._format_error(rd)) from None
-        try:
-            body_text = body_content.decode("utf-8") if body_content else ""
-            rd = json.loads(body_text) if body_text else {}
-            rd.setdefault("status", response.status)
-            if "detail" in rd and "reqId" in str(rd.get("detail", "")):
-                rd_buf = "- " + str(rd["detail"])
-                rd_buf = rd_buf.replace(": ", ", Error: ").replace(", ", "\n- ")
-                rd["detail"] = rd_buf
-        except json.JSONDecodeError:
-            rd_raw: Union[bytes, str] = body_content
-            # todo: Add WWW-Authenticate logic
-            if isinstance(rd_raw, bytes):
-                rd_raw = rd_raw.decode("utf-8")[5:]  ## remove "data:" prefix
-            try:
-                rd = json.loads(rd_raw)
-            except Exception:
-                rd = {"detail": rd_raw}
-
-        message = self._format_error(rd)
-        # todo: raise as an HTTPError
-        raise Exception(message) from None
-
-    ###################################################################################
-    ## Generation interface to allow users to generate new values from endpoints ######
-
-    def get_req(
-        self,
-        payload: dict = {},
-        extra_headers: dict = {},
-    ) -> Response:
-        """Post to the API."""
-        response, session = self._post(
-            self.infer_url, payload, extra_headers=extra_headers
-        )
-        return self._wait(response, session)
 
     def postprocess(
         self,
@@ -729,6 +578,24 @@ class _NVIDIAClient(BaseModel):
             content_holder.update(finish_reason=finish_reason_holder)
         return content_holder, is_stopped
 
+
+class _NVIDIASyncClient(_NVIDIAClientBase):
+    """Synchronous request interface built on top of the shared base."""
+
+    ###################################################################################
+    ## Generation interface to allow users to generate new values from endpoints ######
+
+    def get_req(
+        self,
+        payload: dict = {},
+        extra_headers: dict = {},
+    ) -> Response:
+        """Post to the API."""
+        response, session = self._post(
+            self.infer_url, payload, extra_headers=extra_headers
+        )
+        return self._wait(response, session)
+
     ###################################################################################
     ## Streaming interface to allow you to iterate through progressive generations ####
 
@@ -747,10 +614,10 @@ class _NVIDIAClient(BaseModel):
         }
 
         response = self.get_session_fn().post(
-            stream=True, **self.__add_authorization(self.last_inputs)
+            stream=True, **self._add_authorization(self.last_inputs)
         )
         self._try_raise(response)
-        call: _NVIDIAClient = self.model_copy()
+        call: _NVIDIASyncClient = self.model_copy()
 
         def out_gen() -> Generator[dict, Any, Any]:
             ## Good for client, since it allows self.last_inputs
@@ -762,6 +629,150 @@ class _NVIDIAClient(BaseModel):
                 self._try_raise(response)
 
         return (r for r in out_gen())
+
+
+class _NVIDIAAsyncClient(_NVIDIAClientBase):
+    """Asynchronous request interface built on top of the shared base."""
+
+    get_async_session_fn: Callable = Field(aiohttp.ClientSession)
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        self.get_async_session_fn = self._create_async_session
+
+    def _build_ssl_context(self) -> Union[bool, ssl.SSLContext]:
+        """Build an SSL context for aiohttp based on `verify_ssl` setting."""
+        if isinstance(self.verify_ssl, bool):
+            return self.verify_ssl
+        if isinstance(self.verify_ssl, str):
+            context = ssl.create_default_context(cafile=self.verify_ssl)
+            return context
+        return True
+
+    def _create_async_session(self) -> "aiohttp.ClientSession":
+        """Create an aiohttp session with SSL verification via connector."""
+        connector = aiohttp.TCPConnector(ssl=self._build_ssl_context())
+        return aiohttp.ClientSession(connector=connector)
+
+    async def _post_async(
+        self,
+        invoke_url: str,
+        payload: Optional[dict] = {},
+        extra_headers: dict = {},
+    ) -> Tuple[aiohttp.ClientResponse, aiohttp.ClientSession]:
+        """Async version of `_post`"""
+        self.last_inputs = {
+            "url": invoke_url,
+            "headers": {
+                **self.headers_tmpl["call"],
+                **extra_headers,
+            },
+            "json": payload,
+        }
+        session = self.get_async_session_fn()
+        try:
+            self.last_response = response = await session.post(
+                **self._add_authorization(self.last_inputs)
+            )
+            await self._try_raise_async(response)
+            return response, session
+        except:
+            await session.close()
+            raise
+
+    async def _get_async(
+        self,
+        invoke_url: str,
+    ) -> Tuple[aiohttp.ClientResponse, aiohttp.ClientSession]:
+        """Async version of `_get`"""
+        self.last_inputs = {
+            "url": invoke_url,
+            "headers": self.headers_tmpl["call"],
+        }
+        session = self.get_async_session_fn()
+        try:
+            self.last_response = response = await session.get(
+                **self._add_authorization(self.last_inputs)
+            )
+            await self._try_raise_async(response)
+            return response, session
+        except:
+            await session.close()
+            raise
+
+    async def _wait_async(
+        self,
+        response: aiohttp.ClientResponse,
+        session: aiohttp.ClientSession,
+    ) -> aiohttp.ClientResponse:
+        """Async version of `_wait`"""
+        loop = asyncio.get_event_loop()
+        start_time = loop.time()
+        # note: the local NIM does not return a 202 status code
+        #       (per RL 22may2024 circa 24.05)
+        while response.status == 202:
+            await asyncio.sleep(self.interval)
+            if (loop.time() - start_time) > self.timeout:
+                raise TimeoutError(
+                    f"Timeout reached without a successful response."
+                    f"\nLast response: {str(response)}"
+                )
+            assert (
+                "NVCF-REQID" in response.headers
+            ), "Received 202 response with no request id to follow"
+            request_id = response.headers.get("NVCF-REQID")
+            payload = {
+                "url": self.polling_url_tmpl.format(request_id=request_id),
+                "headers": self.headers_tmpl["call"],
+            }
+            self.last_response = response = await session.get(
+                **self._add_authorization(payload)
+            )
+        await self._try_raise_async(response)
+        return response
+
+    async def _try_raise_async(self, response: aiohttp.ClientResponse) -> None:
+        """Async version of `_try_raise` for `aiohttp` responses."""
+        # todo: Add unit tests for _try_raise_async and _try_raise
+        if response.status < 400:
+            return
+
+        # Read error body before session closes
+        try:
+            body_content = await response.read()
+            # Cache response body content in an additional _cached_content attribute
+            # as aiohttp.ClientResponse can only be read once. This allows tests and
+            # debugging tools to access the error response after it has been consumed
+            # by the _try_raise_async method.
+            response._cached_content = body_content  # type: ignore[attr-defined]
+        except Exception as e:
+            rd = {
+                "status": response.status,
+                "reason": response.reason,
+                "detail": f"Failed to read response body: {e}",
+            }
+            raise Exception(self._format_error(rd)) from None
+        try:
+            body_text = body_content.decode("utf-8") if body_content else ""
+            rd = json.loads(body_text) if body_text else {}
+            rd.setdefault("status", response.status)
+            if "detail" in rd and "reqId" in str(rd.get("detail", "")):
+                rd_buf = "- " + str(rd["detail"])
+                rd_buf = rd_buf.replace(": ", ", Error: ").replace(", ", "\n- ")
+                rd["detail"] = rd_buf
+        except json.JSONDecodeError:
+            rd_raw: Union[bytes, str] = body_content
+            # todo: Add WWW-Authenticate logic
+            if isinstance(rd_raw, bytes):
+                rd_raw = rd_raw.decode("utf-8")[5:]  ## remove "data:" prefix
+            try:
+                rd = json.loads(rd_raw)
+            except Exception:
+                rd = {"detail": rd_raw}
+
+        message = self._format_error(rd)
+        # todo: raise as an HTTPError
+        raise Exception(message) from None
 
     ###################################################################################
     ## Async generation and streaming interfaces ######################################
@@ -800,10 +811,10 @@ class _NVIDIAClient(BaseModel):
         session = self.get_async_session_fn()
         try:
             self.last_response = response = await session.post(
-                **self.__add_authorization(self.last_inputs)
+                **self._add_authorization(self.last_inputs)
             )
             await self._try_raise_async(response)
-            call: _NVIDIAClient = self.model_copy()
+            call: _NVIDIAAsyncClient = self.model_copy()
 
             reader = response.content
             while True:
@@ -818,3 +829,21 @@ class _NVIDIAClient(BaseModel):
                 await self._try_raise_async(response)
         finally:
             await session.close()
+
+
+def _build_clients(
+    **kwargs: Any,
+) -> Tuple[_NVIDIASyncClient, _NVIDIAAsyncClient]:
+    """Build an independent (sync, async) client pair with a single validation pass.
+
+    Each client is fully self-contained — neither holds a reference to the other.
+    We run `_finalize` once on the sync client and copy the resolved fields and
+    cached model list to the async client so warnings and the `/v1/models` call
+    don't fire twice per LangChain instance.
+    """
+    sync = _NVIDIASyncClient(**kwargs)
+    sync._finalize()
+    resolved = {f: getattr(sync, f) for f in _NVIDIAClientBase.model_fields}
+    async_ = _NVIDIAAsyncClient(**resolved)
+    async_._available_models = sync._available_models
+    return sync, async_

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -42,7 +42,7 @@ _API_KEY_VAR = "NVIDIA_API_KEY"
 _BASE_URL_VAR = "NVIDIA_BASE_URL"
 
 
-class _NVIDIAClientBase(BaseModel):
+class _NVIDIABaseClient(BaseModel):
     """Low level client library interface to NIM endpoints."""
 
     default_hosted_model_name: str = Field(..., description="Default model name to use")
@@ -583,7 +583,7 @@ class _NVIDIAClientBase(BaseModel):
         return content_holder, is_stopped
 
 
-class _NVIDIASyncClient(_NVIDIAClientBase):
+class _NVIDIASyncClient(_NVIDIABaseClient):
     """Synchronous request interface built on top of the shared base."""
 
     ###################################################################################
@@ -635,7 +635,7 @@ class _NVIDIASyncClient(_NVIDIAClientBase):
         return (r for r in out_gen())
 
 
-class _NVIDIAAsyncClient(_NVIDIAClientBase):
+class _NVIDIAAsyncClient(_NVIDIABaseClient):
     """Asynchronous request interface built on top of the shared base."""
 
     get_async_session_fn: Callable = Field(aiohttp.ClientSession)
@@ -847,7 +847,7 @@ def _build_clients(
     """
     sync = _NVIDIASyncClient(**kwargs)
     sync._finalize()
-    resolved = {f: getattr(sync, f) for f in _NVIDIAClientBase.model_fields}
+    resolved = {f: getattr(sync, f) for f in _NVIDIABaseClient.model_fields}
     async_ = _NVIDIAAsyncClient(**resolved)
     async_._available_models = sync._available_models
     return sync, async_

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -197,6 +197,10 @@ class _NVIDIAClientBase(BaseModel):
     # final validation after model is constructed
     # todo: when pydantic v2 is available,
     #       use __post_init__ or model_validator(method="after")
+    # NOTE: `_build_clients` runs this once on the sync client and copies
+    # pydantic model_fields plus `_available_models` to the async client.
+    # Any new attribute set here that is NOT a model field must be propagated
+    # explicitly in `_build_clients`, or the async client will be missing it.
     def _finalize(self) -> None:
         self.is_hosted = urlparse(self.base_url).netloc in [
             "integrate.api.nvidia.com",

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -971,7 +971,7 @@ class ChatNVIDIA(BaseChatModel):
     def _get_payload(
         self, inputs: Sequence[Dict], **kwargs: Any
     ) -> dict:  # todo: remove
-        """Generates payload for the `_NVIDIASyncClient` API to send to service."""
+        """Generates payload for the `_NVIDIABaseClient` API to send to service."""
         messages: List[Dict[str, Any]] = []
 
         for msg in inputs:

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -63,7 +63,11 @@ from langchain_core.utils.pydantic import is_basemodel_subclass
 from langchain_core.utils.utils import _build_model_kwargs
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
-from langchain_nvidia_ai_endpoints._common import _NVIDIAClient
+from langchain_nvidia_ai_endpoints._common import (
+    _build_clients,
+    _NVIDIAAsyncClient,
+    _NVIDIASyncClient,
+)
 from langchain_nvidia_ai_endpoints._statics import Model
 from langchain_nvidia_ai_endpoints._utils import convert_message_to_dict
 from langchain_nvidia_ai_endpoints.data._profiles import _PROFILES
@@ -393,7 +397,8 @@ class ChatNVIDIA(BaseChatModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    _client: _NVIDIAClient = PrivateAttr()
+    _client: _NVIDIASyncClient = PrivateAttr()
+    _async_client: _NVIDIAAsyncClient = PrivateAttr()
 
     base_url: Optional[str] = Field(
         default=None,
@@ -554,7 +559,7 @@ class ChatNVIDIA(BaseChatModel):
         # Extract verify_ssl from kwargs, default to True
         verify_ssl = kwargs.pop("verify_ssl", True)
 
-        self._client = _NVIDIAClient(
+        self._client, self._async_client = _build_clients(
             **({"base_url": base_url} if base_url else {}),  # only pass if set
             mdl_name=self.model,
             default_hosted_model_name=_DEFAULT_MODEL_NAME,
@@ -786,7 +791,7 @@ class ChatNVIDIA(BaseChatModel):
         _, payload, extra_headers = self._prepare_inputs_and_payload(
             messages, stop, stream=False, **kwargs
         )
-        response = await self._client.aget_req(
+        response = await self._async_client.aget_req(
             payload=payload, extra_headers=extra_headers
         )
         return self._process_generate_response(
@@ -805,7 +810,7 @@ class ChatNVIDIA(BaseChatModel):
             messages, stop, stream=True, **kwargs
         )
         structured_output = _is_structured_output(payload)
-        async for response in self._client.aget_req_stream(
+        async for response in self._async_client.aget_req_stream(
             payload=payload, extra_headers=extra_headers
         ):
             chunk = self._process_stream_chunk(response, run_manager, structured_output)
@@ -966,7 +971,7 @@ class ChatNVIDIA(BaseChatModel):
     def _get_payload(
         self, inputs: Sequence[Dict], **kwargs: Any
     ) -> dict:  # todo: remove
-        """Generates payload for the `_NVIDIAClient` API to send to service."""
+        """Generates payload for the `_NVIDIASyncClient` API to send to service."""
         messages: List[Dict[str, Any]] = []
 
         for msg in inputs:

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
@@ -10,7 +10,11 @@ from pydantic import (
     PrivateAttr,
 )
 
-from langchain_nvidia_ai_endpoints._common import _NVIDIAClient
+from langchain_nvidia_ai_endpoints._common import (
+    _build_clients,
+    _NVIDIAAsyncClient,
+    _NVIDIASyncClient,
+)
 from langchain_nvidia_ai_endpoints._statics import Model
 from langchain_nvidia_ai_endpoints.callbacks import usage_callback_var
 
@@ -35,7 +39,8 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
         validate_assignment=True,
     )
 
-    _client: _NVIDIAClient = PrivateAttr()
+    _client: _NVIDIASyncClient = PrivateAttr()
+    _async_client: _NVIDIAAsyncClient = PrivateAttr()
 
     base_url: Optional[str] = Field(
         default=None,
@@ -135,7 +140,7 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
         # Extract verify_ssl from kwargs, default to True
         verify_ssl = kwargs.pop("verify_ssl", True)
 
-        self._client = _NVIDIAClient(
+        self._client, self._async_client = _build_clients(
             **({"base_url": base_url} if base_url else {}),  # only pass if set
             mdl_name=self.model,
             default_hosted_model_name=_DEFAULT_MODEL_NAME,
@@ -260,7 +265,7 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
     ) -> List[List[float]]:
         """Async version of _embed."""
         payload = self._prepare_payload(texts, model_type)
-        response_text = await self._client.aget_req(
+        response_text = await self._async_client.aget_req(
             payload=payload,
             extra_headers=self.default_headers,
         )

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/llm.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/llm.py
@@ -12,7 +12,11 @@ from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
 from pydantic import ConfigDict, Field, PrivateAttr
 
-from langchain_nvidia_ai_endpoints._common import _NVIDIAClient
+from langchain_nvidia_ai_endpoints._common import (
+    _build_clients,
+    _NVIDIAAsyncClient,
+    _NVIDIASyncClient,
+)
 from langchain_nvidia_ai_endpoints._statics import Model
 
 _DEFAULT_MODEL_NAME: str = "nvidia/mistral-nemo-minitron-8b-base"
@@ -25,7 +29,8 @@ class NVIDIA(LLM):
         validate_assignment=True,
     )
 
-    _client: _NVIDIAClient = PrivateAttr()
+    _client: _NVIDIASyncClient = PrivateAttr()
+    _async_client: _NVIDIAAsyncClient = PrivateAttr()
 
     _default_model_name: str = "nvidia/mistral-nemo-minitron-8b-base"
 
@@ -117,7 +122,7 @@ class NVIDIA(LLM):
         # Extract verify_ssl from kwargs, default to True
         verify_ssl = kwargs.pop("verify_ssl", True)
 
-        self._client = _NVIDIAClient(
+        self._client, self._async_client = _build_clients(
             **({"base_url": base_url} if base_url else {}),  # only pass if set
             mdl_name=self.model,
             default_hosted_model_name=_DEFAULT_MODEL_NAME,
@@ -293,7 +298,7 @@ class NVIDIA(LLM):
         **kwargs: Any,
     ) -> str:
         payload = self._prepare_call_payload(prompt, stop, **kwargs)
-        response_text = await self._client.aget_req(payload=payload)
+        response_text = await self._async_client.aget_req(payload=payload)
         result = json.loads(response_text)
         return self._process_result(result)
 
@@ -305,7 +310,7 @@ class NVIDIA(LLM):
         **kwargs: Any,
     ) -> AsyncIterator[GenerationChunk]:
         payload = self._prepare_stream_payload(prompt, stop, **kwargs)
-        async for chunk in self._client.aget_req_stream(payload=payload):
+        async for chunk in self._async_client.aget_req_stream(payload=payload):
             content = chunk["content"]
             generation = GenerationChunk(text=content)
             if run_manager:

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
@@ -14,7 +14,11 @@ from pydantic import (
     PrivateAttr,
 )
 
-from langchain_nvidia_ai_endpoints._common import _NVIDIAClient
+from langchain_nvidia_ai_endpoints._common import (
+    _build_clients,
+    _NVIDIAAsyncClient,
+    _NVIDIASyncClient,
+)
 from langchain_nvidia_ai_endpoints._statics import Model
 
 
@@ -36,7 +40,8 @@ class NVIDIARerank(BaseDocumentCompressor):
         validate_assignment=True,
     )
 
-    _client: _NVIDIAClient = PrivateAttr()
+    _client: _NVIDIASyncClient = PrivateAttr()
+    _async_client: _NVIDIAAsyncClient = PrivateAttr()
 
     base_url: Optional[str] = Field(
         default=None,
@@ -175,7 +180,7 @@ class NVIDIARerank(BaseDocumentCompressor):
         # Extract verify_ssl from kwargs, default to True
         verify_ssl = kwargs.pop("verify_ssl", True)
 
-        self._client = _NVIDIAClient(
+        self._client, self._async_client = _build_clients(
             **({"base_url": base_url} if base_url else {}),  # only pass if set
             mdl_name=self.model,
             default_hosted_model_name=_DEFAULT_MODEL_NAME,
@@ -329,7 +334,7 @@ class NVIDIARerank(BaseDocumentCompressor):
     async def _arank(self, documents: List[str], query: str) -> List[Ranking]:
         """Async version of _rank."""
         payload = self._prepare_payload(documents, query)
-        response_text = await self._client.aget_req(
+        response_text = await self._async_client.aget_req(
             payload=payload, extra_headers=self.default_headers
         )
         result = json.loads(response_text)

--- a/libs/ai-endpoints/tests/unit_tests/conftest.py
+++ b/libs/ai-endpoints/tests/unit_tests/conftest.py
@@ -13,7 +13,7 @@ from langchain_nvidia_ai_endpoints import (
     NVIDIAEmbeddings,
     NVIDIARerank,
 )
-from langchain_nvidia_ai_endpoints._common import _NVIDIAClient
+from langchain_nvidia_ai_endpoints._common import _NVIDIAAsyncClient
 from langchain_nvidia_ai_endpoints._statics import MODEL_TABLE
 
 
@@ -181,7 +181,10 @@ def mock_http(
     aio_sess.get.side_effect = _get_side_effect
 
     monkeypatch.setattr(
-        _NVIDIAClient, "_create_async_session", lambda self: aio_sess, raising=True
+        _NVIDIAAsyncClient,
+        "_create_async_session",
+        lambda self: aio_sess,
+        raising=True,
     )
 
     return MockHTTP(requests_mock, aio_sess, _history)

--- a/libs/ai-endpoints/tests/unit_tests/test_available_models.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_available_models.py
@@ -5,7 +5,7 @@ from typing import Any
 import requests_mock as rm
 
 from langchain_nvidia_ai_endpoints import ChatNVIDIA, Model, register_model
-from langchain_nvidia_ai_endpoints._common import _NVIDIAClient
+from langchain_nvidia_ai_endpoints._common import _NVIDIASyncClient
 
 
 def test_model_listing(public_class: Any, mock_model: str) -> None:
@@ -42,7 +42,7 @@ def test_duplicate_models_in_api_response(
 
     Regression test for the case where /v1/models returns the same model id
     more than once (e.g. nvidia/nemotron-3-super-120b-a12b). Previously this
-    triggered an AssertionError in _NVIDIAClient.__init__.
+    triggered an AssertionError in _NVIDIASyncClient.__init__.
     """
     duplicate_model = "test-org/duplicate-model"
     requests_mock.get(
@@ -81,7 +81,7 @@ def test_duplicate_models_deduplicated_in_available_models(
         client = ChatNVIDIA(model=duplicate_model)
     # Access the internal client's cached model list (API-only, before
     # get_available_models merges in the static MODEL_TABLE)
-    internal: _NVIDIAClient = client._client  # type: ignore[attr-defined]
+    internal: _NVIDIASyncClient = client._client  # type: ignore[attr-defined]
     ids = [m.id for m in internal.available_models]
     assert ids.count(duplicate_model) == 1
     assert ids.count("test-org/unique-model") == 1

--- a/libs/ai-endpoints/tests/unit_tests/test_available_models.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_available_models.py
@@ -35,6 +35,42 @@ def test_model_listing_hosted(
     assert any(model.id == mock_model for model in models)
 
 
+def test_single_models_call_per_instance(
+    requests_mock: rm.Mocker,
+) -> None:
+    """Constructing a public class should hit /v1/models and emit each warning
+    at most once.
+
+    Regression test for the sync/async client split: `_build_clients` runs
+    `_finalize` once on the sync client and copies resolved fields plus
+    `_available_models` to the async client. If that ever regresses to
+    instantiating two fully-validated clients, /v1/models would be fetched
+    twice and `_finalize` warnings would double up.
+    """
+    unknown_model = "test-org/unknown-model"
+    requests_mock.get(
+        re.compile(".*/v1/models"),
+        json={"data": [{"id": "test-org/something-else"}]},
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ChatNVIDIA(model=unknown_model, api_key="BOGUS")
+
+    models_calls = [
+        req for req in requests_mock.request_history if req.path.endswith("/v1/models")
+    ]
+    assert (
+        len(models_calls) == 1
+    ), f"expected 1 /v1/models call, got {len(models_calls)}"
+
+    unknown_warnings = [w for w in caught if "is unknown" in str(w.message)]
+    assert len(unknown_warnings) == 1, (
+        f"expected 1 'is unknown' warning, got {len(unknown_warnings)}: "
+        f"{[str(w.message) for w in unknown_warnings]}"
+    )
+
+
 def test_duplicate_models_in_api_response(
     requests_mock: rm.Mocker,
 ) -> None:


### PR DESCRIPTION
## Summary

Splits `_NVIDIAClient` into a shared `_NVIDIABaseClient` + dedicated `_NVIDIASyncClient` and `_NVIDIAAsyncClient`, each fully self-contained. A new `_build_clients()` factory constructs both clients with a single validation pass — `_finalize()` runs once on the sync client and resolved fields plus the cached `/v1/models` list are copied to the async client.

The four public classes (`ChatNVIDIA`, `NVIDIA`, `NVIDIAEmbeddings`, `NVIDIARerank`) now hold both `_client` (sync) and `_async_client` (async) as private attrs. Async paths route through `_async_client`; sync paths through `_client`.

## Why

- `_finalize()`-driven warnings and the `/v1/models` HTTP call no longer fire twice per LangChain instance.
- Sync and async transport state (`last_inputs`, `last_response`) is no longer shared across paths, eliminating cross-path races.
- Cleaner separation between `requests`-based and `aiohttp`-based machinery.

## Behavior change worth noting

Before this PR, `instance._client.last_response` reflected the most recent call regardless of whether it was sync or async. After this PR, `_client.last_response` only reflects sync calls; the async equivalent is on `_async_client.last_response`. Both are private attrs so no public API is affected, but anyone reading them in custom code should switch.

## Tests

- All existing unit tests updated (`conftest.py` now monkeypatches `_NVIDIAAsyncClient._create_async_session`; `test_available_models.py` types updated to `_NVIDIASyncClient`).
- New regression test `test_single_models_call_per_instance` asserts that constructing a public class makes exactly one `/v1/models` request and emits the model-validation warning exactly once. Verified that this test fails when `_finalize()` is incorrectly run on both clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)