### PR TITLE
test: fix integration tests after model deprecations and async client refactor

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -349,6 +349,7 @@ class ChatNVIDIA(BaseChatModel):
     max_tokens: Optional[int] = Field(
         1024,
         gt=0,
+        lt=2**31 - 1,
         description="Maximum # of tokens to generate",
         alias="max_completion_tokens",
     )

--- a/libs/ai-endpoints/tests/integration_tests/test_api_key.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_api_key.py
@@ -4,12 +4,18 @@ from typing import Any
 import pytest
 from langchain_core.messages import HumanMessage
 
-from langchain_nvidia_ai_endpoints import ChatNVIDIA
+from langchain_nvidia_ai_endpoints import NVIDIA, ChatNVIDIA
 
 from ..unit_tests.test_api_key import no_env_var
 
 
-def test_missing_api_key_error(public_class: type, contact_service: Any) -> None:
+def test_missing_api_key_error(
+    public_class: type, contact_service: Any, mode: dict
+) -> None:
+    if public_class is NVIDIA and public_class(**mode)._client.is_hosted:
+        pytest.skip(
+            "NVIDIA completions models are all deprecated on the hosted endpoint"
+        )
     with no_env_var("NVIDIA_API_KEY"):
         with pytest.warns(UserWarning) as record:
             client = public_class()
@@ -23,7 +29,13 @@ def test_missing_api_key_error(public_class: type, contact_service: Any) -> None
         assert "API key" in message
 
 
-def test_bogus_api_key_error(public_class: type, contact_service: Any) -> None:
+def test_bogus_api_key_error(
+    public_class: type, contact_service: Any, mode: dict
+) -> None:
+    if public_class is NVIDIA and public_class(**mode)._client.is_hosted:
+        pytest.skip(
+            "NVIDIA completions models are all deprecated on the hosted endpoint"
+        )
     with no_env_var("NVIDIA_API_KEY"):
         client = public_class(nvidia_api_key="BOGUS")
         with pytest.raises(Exception) as exc_info:
@@ -35,7 +47,13 @@ def test_bogus_api_key_error(public_class: type, contact_service: Any) -> None:
 
 
 @pytest.mark.parametrize("param", ["nvidia_api_key", "api_key"])
-def test_api_key(public_class: type, param: str, contact_service: Any) -> None:
+def test_api_key(
+    public_class: type, param: str, contact_service: Any, mode: dict
+) -> None:
+    if public_class is NVIDIA and public_class(**mode)._client.is_hosted:
+        pytest.skip(
+            "NVIDIA completions models are all deprecated on the hosted endpoint"
+        )
     api_key = os.environ.get("NVIDIA_API_KEY")
     with no_env_var("NVIDIA_API_KEY"):
         client = public_class(**{param: api_key})

--- a/libs/ai-endpoints/tests/integration_tests/test_chat_models.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_chat_models.py
@@ -304,27 +304,13 @@ async def test_ai_endpoints_invoke_max_tokens_negative_b(
     max_tokens: int,
     func: str,
 ) -> None:
-    """Test invoke's max_tokens' positive bounds."""
+    """Test invoke's max_tokens' positive bounds (caught by client-side validation)."""
     with pytest.raises(Exception):
         llm = ChatNVIDIA(model=chat_model, max_tokens=max_tokens, **mode)
         if func == "invoke":
             llm.invoke("Show me the tokens")
         else:
             await llm.ainvoke("Show me the tokens")
-    assert llm._client.last_response is not None
-    # custom error string -
-    #    model inference failed -- ValueError: A requested length of the model output
-    #    is too big. Maximum allowed output length is X, whereas requested output
-    #    length is Y.
-    #  or
-    #    body -> max_tokens
-    #    Input should be less than or equal to 2048 (type=less_than_equal; le=2048)
-    assert_response_error(
-        llm._client.last_response,
-        [400, 422],
-        lambda content: "length" in content
-        or ("max_tokens" in content and "less_than_equal" in content),
-    )
 
 
 @pytest.mark.parametrize(
@@ -400,11 +386,12 @@ async def test_ai_endpoints_invoke_seed_range(
         llm.invoke("What's in a seed?")
     else:
         await llm.ainvoke("What's in a seed?")
-    assert llm._client.last_response is not None
+    client = llm._async_client if func == "ainvoke" else llm._client
+    assert client.last_response is not None
     if func == "ainvoke":
-        assert llm._client.last_response.status == 200  # type: ignore[union-attr]
+        assert client.last_response.status == 200  # type: ignore[union-attr]
     else:
-        assert llm._client.last_response.status_code == 200  # type: ignore[union-attr]
+        assert client.last_response.status_code == 200  # type: ignore[union-attr]
 
 
 @pytest.mark.xfail(reason="seed does not consistently control determinism")

--- a/libs/ai-endpoints/tests/integration_tests/test_completions_models.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_completions_models.py
@@ -60,6 +60,19 @@ from typing import Any, Callable, Tuple
 import pytest
 
 from langchain_nvidia_ai_endpoints import NVIDIA
+from langchain_nvidia_ai_endpoints.llm import _DEFAULT_MODEL_NAME
+
+
+@pytest.fixture(autouse=True)
+def _skip_default_completions_model(completions_model: str, mode: dict) -> None:
+    if (
+        NVIDIA(model=completions_model, **mode)._client.is_hosted
+        and completions_model == _DEFAULT_MODEL_NAME
+    ):
+        pytest.skip(
+            "Default completions model is deprecated on the hosted endpoint; "
+            "pass --completions-model-id to run these tests."
+        )
 
 
 def is_async_func(func: Callable) -> bool:

--- a/libs/ai-endpoints/tests/integration_tests/test_ranking.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_ranking.py
@@ -290,5 +290,5 @@ async def test_truncate_negative(
             client.compress_documents(documents=documents, query=query)
         else:  # acompress
             await client.acompress_documents(documents=documents, query=query)
-    assert "400" in str(e.value)
+    assert "400" in str(e.value) or "422" in str(e.value)
     assert "exceeds maximum allowed" in str(e.value)

--- a/libs/ai-endpoints/tests/integration_tests/test_register_model.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_register_model.py
@@ -22,7 +22,7 @@ from langchain_nvidia_ai_endpoints import (
         (
             ChatNVIDIA,
             "meta/llama-3.1-8b-instruct",
-            "https://integrate.api.nvidia.com/v1/chat/completions",
+            "https://api.nvcf.nvidia.com/v2/nvcf/pexec/functions/e62a4350-2218-4cf5-9262-112432d239f8",
         ),
         (
             NVIDIAEmbeddings,

--- a/libs/ai-endpoints/tests/integration_tests/test_register_model.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_register_model.py
@@ -4,7 +4,6 @@ from typing import Any
 import pytest
 
 from langchain_nvidia_ai_endpoints import (
-    NVIDIA,
     ChatNVIDIA,
     Model,
     NVIDIAEmbeddings,
@@ -23,7 +22,7 @@ from langchain_nvidia_ai_endpoints import (
         (
             ChatNVIDIA,
             "meta/llama-3.1-8b-instruct",
-            "https://api.nvcf.nvidia.com/v2/nvcf/pexec/functions/a5a3ad64-ec2c-4bfc-8ef7-5636f26630fe",
+            "https://integrate.api.nvidia.com/v1/chat/completions",
         ),
         (
             NVIDIAEmbeddings,
@@ -34,11 +33,6 @@ from langchain_nvidia_ai_endpoints import (
             NVIDIARerank,
             "nv-rerank-qa-mistral-4b:1",
             "https://api.nvcf.nvidia.com/v2/nvcf/pexec/functions/0bf77f50-5c35-4488-8e7a-f49bb1974af6",
-        ),
-        (
-            NVIDIA,
-            "bigcode/starcoder2-7b",
-            "https://api.nvcf.nvidia.com/v2/nvcf/pexec/functions/dd7b01e7-732d-4da5-8e8d-315f79165a23",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

Fix integration test failures from recent model deprecations (`6046644`) and the async client refactor (`c3f72d0`).

- Cap `max_tokens` client-side at `< 2**31 - 1` so overflow is rejected uniformly instead of relying on per-model server validation.
- Skip `NVIDIA` (completions) cases in `test_api_key` on hosted endpoints — every registered completions model is deprecated.
- Skip `test_completions_models` when running with the default model on hosted; pass `--completions-model-id` to opt in.
- Read `last_response` from the matching client (`_client` for sync, `_async_client` for async) — they no longer share state after the refactor.
- Accept `400` or `422` in `test_truncate_negative` (rerank endpoint now returns `422`).