### PR TITLE
fix: add mistralai/ministral-3-14b-instruct-2512 to _statics.py

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -993,6 +993,11 @@ VLM_MODEL_TABLE = {
         model_type="vlm",
         client="ChatNVIDIA",
     ),
+   "mistralai/ministral-3-14b-instruct-2512": Model(
+        id="mistralai/ministral-3-14b-instruct-2512",
+        model_type="vlm",
+      	client="ChatNVIDIA",
+    ),
     "mistralai/mistral-large-3-675b-instruct-2512": Model(
         id="mistralai/mistral-large-3-675b-instruct-2512",
         model_type="vlm",

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -997,6 +997,7 @@ VLM_MODEL_TABLE = {
         id="mistralai/ministral-3-14b-instruct-2512",
         model_type="vlm",
         client="ChatNVIDIA",
+        supports_tools=True,
     ),
     "mistralai/mistral-large-3-675b-instruct-2512": Model(
         id="mistralai/mistral-large-3-675b-instruct-2512",

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -993,10 +993,10 @@ VLM_MODEL_TABLE = {
         model_type="vlm",
         client="ChatNVIDIA",
     ),
-   "mistralai/ministral-3-14b-instruct-2512": Model(
+    "mistralai/ministral-3-14b-instruct-2512": Model(
         id="mistralai/ministral-3-14b-instruct-2512",
         model_type="vlm",
-      	client="ChatNVIDIA",
+        client="ChatNVIDIA",
     ),
     "mistralai/mistral-large-3-675b-instruct-2512": Model(
         id="mistralai/mistral-large-3-675b-instruct-2512",


### PR DESCRIPTION
The downloadable NIM container serves the model as mistralai/ministral-3-14b-instruct-2512 but _statics.py only had mistralai/ministral-14b-instruct-2512. This mismatch caused VLM preprocessing to be skipped for local NIM deployments, sending raw file paths instead of base64 data URIs to the container.
Verified: adding this entry fixes 14 VLM file/image tests against a local ministral-3-14b NIM container.