### PR TITLE
fix: include 'message' field in error response parsing

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -473,7 +473,11 @@ class _NVIDIABaseClient(BaseModel):
         """Format error dictionary"""
         status = rd.get("status") or rd.get("status_code") or "###"
         title = (
-            rd.get("title") or rd.get("message") or rd.get("error") or rd.get("reason") or "Unknown Error"
+            rd.get("title")
+            or rd.get("message")
+            or rd.get("error")
+            or rd.get("reason")
+            or "Unknown Error"
         )
         header = f"[{status}] {title}"
         body = ""

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -473,7 +473,7 @@ class _NVIDIABaseClient(BaseModel):
         """Format error dictionary"""
         status = rd.get("status") or rd.get("status_code") or "###"
         title = (
-            rd.get("title") or rd.get("error") or rd.get("reason") or "Unknown Error"
+            rd.get("title") or rd.get("message") or rd.get("error") or rd.get("reason") or "Unknown Error"
         )
         header = f"[{status}] {title}"
         body = ""


### PR DESCRIPTION
NIM containers return error details in a 'message' field (e.g. {"object":"error","message":"Input length 12007 exceeds
maximum allowed token size 8192",...}). The existing parser only  checked 'title', 'error', and 'reason', causing these errors to
surface as '[422] Unknown Error' with no actionable detail.
Verified: fixes 4 reranker test_truncate_negative failures against a local llama-nemotron-rerank-1b-v2 NIM container.