### PR TITLE
fix(ai-endpoints): report per-invocation model in traces

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -541,7 +541,7 @@ class ChatNVIDIA(BaseChatModel):
             ls_provider="NVIDIA",
             # error: Incompatible types (expression has type "Optional[str]",
             #  TypedDict item "ls_model_name" has type "str")  [typeddict-item]
-            ls_model_name=self.model or "UNKNOWN",
+            ls_model_name=params.get("model") or self.model or "UNKNOWN",
             ls_model_type="chat",
             ls_temperature=params.get("temperature", self.temperature),
             # TODO: remove max_tokens once all models support max_completion_tokens


### PR DESCRIPTION
now reads `ls_model_name` from the invocation params before falling back to the instance attribute, so traces reflect the model that actually served the call