### PR TITLE
Fix Feature/nvidia retriever support for RAG v2.6.0

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/retrievers.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/retrievers.py
@@ -133,9 +133,12 @@ class NVIDIARAGRetriever(BaseRetriever):
         description=("Number of top results from vector DB before reranking."),
     )
 
-    vdb_endpoint: str = Field(
-        default="http://milvus:19530",
-        description="Endpoint URL of the vector database server.",
+    vdb_endpoint: Optional[str] = Field(
+        default=None,
+        description=(
+            "Endpoint URL of the vector database server. "
+            "When omitted, the RAG server uses its configured vector store URL."
+        ),
     )
 
     enable_reranker: bool = Field(
@@ -212,7 +215,6 @@ class NVIDIARAGRetriever(BaseRetriever):
             "query": query,
             "reranker_top_k": self.k,
             "vdb_top_k": self.vdb_top_k,
-            "vdb_endpoint": self.vdb_endpoint,
             "collection_names": self.collection_names,
             "messages": self.messages,
             "enable_query_rewriting": self.enable_query_rewriting,
@@ -221,6 +223,8 @@ class NVIDIARAGRetriever(BaseRetriever):
             "enable_citations": self.enable_citations,
             "confidence_threshold": self.confidence_threshold,
         }
+        if self.vdb_endpoint is not None:
+            payload["vdb_endpoint"] = self.vdb_endpoint
         if self.filter_expr is not None:
             payload["filter_expr"] = self.filter_expr
         if self.embedding_model is not None:

--- a/libs/ai-endpoints/tests/unit_tests/test_retrievers.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_retrievers.py
@@ -72,6 +72,18 @@ def test_nvidia_retriever_build_payload() -> None:
     assert payload["collection_names"] == ["col1"]
     assert payload["enable_reranker"] is True
     assert payload["filter_expr"] == 'content_metadata["x"] == "y"'
+    assert "vdb_endpoint" not in payload
+
+
+def test_nvidia_retriever_build_payload_with_vdb_endpoint() -> None:
+    """Test vdb_endpoint is included only when explicitly set."""
+    retriever = NVIDIARAGRetriever(
+        base_url="http://localhost:8081",
+        collection_names=["col1"],
+        vdb_endpoint="http://elasticsearch:9200",
+    )
+    payload = retriever._build_payload("test query")
+    assert payload["vdb_endpoint"] == "http://elasticsearch:9200"
 
 
 def test_nvidia_retriever_results_to_documents() -> None:
@@ -139,6 +151,7 @@ def test_nvidia_retriever_invoke_success() -> None:
         assert req_body["query"] == "What is AI?"
         assert req_body["collection_names"] == ["test_multimodal_query"]
         assert req_body["reranker_top_k"] == 2
+        assert "vdb_endpoint" not in req_body
 
 
 def test_nvidia_retriever_connection_error() -> None:


### PR DESCRIPTION
NVIDIARAGRetriever always sent vdb_endpoint: "http://milvus:19530" in the /v1/search payload. 
Elasticsearch deployments use a different endpoint.

The LangChain notebook’s basic retrieval cells did not use elasticsearch (which is now default in RAG), so the RAG server was pointed at Milvus instead of the configured Elasticsearch store.

Fix
1. langchain-nvidia — retrievers.py
vdb_endpoint is now optional (None by default).
It is only included in the request when set explicitly.
When omitted, the RAG server uses CONFIG.vector_store.url (Elasticsearch or Milvus, depending on deployment).
