### PR TITLE
add tool support for qwen3.5-122b-a10b

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_statics.py
@@ -1028,6 +1028,7 @@ VLM_MODEL_TABLE = {
         id="qwen/qwen3.5-122b-a10b",
         model_type="vlm",
         client="ChatNVIDIA",
+        supports_tools=True,
         supports_thinking=True,
         thinking_param_enable={"chat_template_kwargs": {"enable_thinking": True}},
         thinking_param_disable={"chat_template_kwargs": {"enable_thinking": False}},


### PR DESCRIPTION
add supports_tools=True to qwen/qwen3.5-122b-a10b in _statics.py. The model was missing this flag, causing test_known_does_not_warn to fail with a spurious UserWarning on bind_tools()