### PR TITLE
Keep ChatNVIDIA verify_ssl out of payload

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -479,18 +479,21 @@ class ChatNVIDIA(BaseChatModel):
         if default_headers is not None:
             init_kwargs["default_headers"] = default_headers
 
+        # allow nvidia_base_url as an alternative for base_url
+        nvidia_base_url = kwargs.pop("nvidia_base_url", None)
+
+        # Extract verify_ssl from kwargs, default to True. This is a client
+        # transport option, not a model parameter.
+        verify_ssl = kwargs.pop("verify_ssl", True)
+
         init_kwargs.update(kwargs)
 
         super().__init__(**init_kwargs)
 
-        # allow nvidia_base_url as an alternative for base_url
-        base_url = kwargs.pop("nvidia_base_url", self.base_url)
+        base_url = nvidia_base_url if nvidia_base_url is not None else self.base_url
 
         # allow nvidia_api_key as an alternative for api_key
         api_key = nvidia_api_key or api_key
-
-        # Extract verify_ssl from kwargs, default to True
-        verify_ssl = kwargs.pop("verify_ssl", True)
 
         self._client, self._async_client = _build_clients(
             **({"base_url": base_url} if base_url else {}),  # only pass if set

--- a/libs/ai-endpoints/tests/unit_tests/test_chat_models.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_chat_models.py
@@ -520,6 +520,13 @@ def test_verify_ssl_behavior(
 
     # Test that session factory creates sessions with correct verify setting
     assert llm._client.get_session_fn().verify is expected_verify_ssl
+    assert "verify_ssl" not in llm.model_kwargs
+
+    payload = llm._get_payload(
+        inputs=[{"role": "user", "content": "test"}],
+        stop=None,
+    )
+    assert "verify_ssl" not in payload
 
 
 def test_default_headers(requests_mock: Mocker) -> None:


### PR DESCRIPTION
## Description

Fixes #313.

`ChatNVIDIA` accepts `verify_ssl` as a client transport option, but it was popped from `kwargs` after `super().__init__(**init_kwargs)`. LangChain extra-kwarg handling therefore moved `verify_ssl` into `model_kwargs`, and `_get_payload()` later merged it into the chat-completions request body.

This change pops constructor/client-only kwargs before `super().__init__()`, so `verify_ssl` still configures the HTTP client while staying out of `model_kwargs` and the generated payload. It also handles the `nvidia_base_url` alias before extra-kwarg processing for the same reason.

## Testing

- `uv run --with-editable ./libs/ai-endpoints --with pytest --with pytest-mock --with requests-mock --with syrupy --with freezegun --with 'langchain-tests>=1.0.0,<2.0.0' python -m pytest libs/ai-endpoints/tests/unit_tests/test_chat_models.py -k 'verify_ssl_behavior'`
- `uv run --with-editable ./libs/ai-endpoints --with pytest --with pytest-mock --with requests-mock --with syrupy --with freezegun --with 'langchain-tests>=1.0.0,<2.0.0' python -m pytest libs/ai-endpoints/tests/unit_tests/test_chat_models.py`
