### PR TITLE
docs(ai-endpoints): replace deprecated `max_tokens` with `max_completion_tokens` in README example

### DIFF
--- a/libs/ai-endpoints/README.md
+++ b/libs/ai-endpoints/README.md
@@ -193,7 +193,7 @@ prompt = ChatPromptTemplate.from_messages(
 )
 chain = (
     prompt
-    | ChatNVIDIA(model="meta/codellama-70b", max_tokens=419)
+    | ChatNVIDIA(model="meta/codellama-70b", max_completion_tokens=419)
     | StrOutputParser()
 )
 


### PR DESCRIPTION
Fixes #167

---

The PyPI-facing README example at line 196 uses `max_tokens` which
triggers a deprecation warning when users copy-paste the example:

```
DeprecationWarning: The 'max_tokens' parameter is deprecated and will
be removed in a future version. Please use 'max_completion_tokens' instead.
```

This updates the example to use the current parameter name.

This contribution was prepared with AI assistance.