### PR TITLE
fix(ai-endpoints): add `stacklevel=2` to URL validation warnings

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -167,7 +167,8 @@ class _NVIDIABaseClient(BaseModel):
                 expected_format = "Expected format is: http://host:port"
                 warnings.warn(
                     "The provided url appears incorrect. "
-                    f"Expected: {expected_format} Got: {v}"
+                    f"Expected: {expected_format} Got: {v}",
+                    stacklevel=2,
                 )
 
             normalized_path = parsed.path.rstrip("/")
@@ -180,6 +181,7 @@ class _NVIDIABaseClient(BaseModel):
                     "you may have inference and listing issues. "
                     "This check will be deprecated in the next release. "
                     "Please ensure /v1 is appended to the provided URL",
+                    stacklevel=2,
                 )
                 normalized_path += "/v1"
 


### PR DESCRIPTION
Two `warnings.warn()` calls in `_common.py` were missing
`stacklevel`, causing URL validation warnings to point at
framework internals instead of the user's call site.

This is consistent with the existing pattern already used in:
- `chat_models.py:468` — `max_tokens` deprecation warning
- `reranking.py:200` — `extra_headers` deprecation warning

No behavior change, no dependency impact.

This contribution was prepared with AI assistance.