### PR TITLE
Release/1.4.3

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_version.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_version.py
@@ -1,3 +1,3 @@
 """Version information for `langchain-nvidia-ai-endpoints`."""
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"

--- a/libs/ai-endpoints/pyproject.toml
+++ b/libs/ai-endpoints/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-nvidia-ai-endpoints"
-version = "1.4.2"
+version = "1.4.3"
 description = "An integration package connecting NVIDIA AI Endpoints and LangChain"
 authors = []
 readme = "README.md"

--- a/libs/ai-endpoints/tests/unit_tests/test_imports.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_imports.py
@@ -23,4 +23,4 @@ def test_all_imports() -> None:
 
 
 def test_version_import() -> None:
-    assert __version__ == "1.4.2"
+    assert __version__ == "1.4.3"


### PR DESCRIPTION
Release langchain-nvidia-ai-endpoints 1.4.3.

This patch release includes the already-merged aiohttp constraint fix from main, so downstream packages can resolve aiohttp 3.14.x instead of being capped below 3.14.

Validation:
- `poetry -C libs/ai-endpoints check`
- `poetry -C libs/ai-endpoints run python - <<'PY' ...` verified pyproject version, package `__version__`, and aiohttp range
- commit appears Verified in GitHub

Signed-off-by: Mason Daugherty <mason@langchain.dev>
