### PR TITLE
Fix self-hosted NIM structured output fallback

### DIFF
--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -1431,16 +1431,11 @@ class ChatNVIDIA(BaseChatModel):
         openai_parser = openai_output_parser or output_parser
         openai_compat_chain = openai_compat_llm | openai_parser
 
-        # For hosted NVIDIA API endpoint: try OpenAI format first,
-        #   then fall back to direct -> nvext
-        # For self-hosted NIMs: try direct -> nvext first,
-        #   then fall back to OpenAI format
-        # The fallback is mostly defensive. The primary format for each
-        # case is expected to succeed.
-        if self._client.is_hosted:
-            chains = [openai_compat_chain] + guided_chains
-        else:
-            chains = guided_chains + [openai_compat_chain]
+        # Try the OpenAI-compatible response_format first for both hosted
+        # endpoints and self-hosted NIMs. Recent NIMs support response_format,
+        # while legacy guided_json/nvext fields may be ignored by vLLM and
+        # return free-form text with HTTP 200.
+        chains = [openai_compat_chain] + guided_chains
 
         from langchain_core.runnables import Runnable, RunnableConfig
 

--- a/libs/ai-endpoints/tests/integration_tests/test_chat_models.py
+++ b/libs/ai-endpoints/tests/integration_tests/test_chat_models.py
@@ -50,6 +50,52 @@ def assert_response_error(
     assert validate_content(content_str)
 
 
+def _is_known_message_shape_error(messages: List[BaseMessage], exc: Exception) -> bool:
+    """Return True when a model rejects a known-optional message pattern."""
+    roles = []
+    for message in messages:
+        if isinstance(message, HumanMessage):
+            roles.append("user")
+        elif isinstance(message, AIMessage):
+            roles.append("assistant")
+        elif isinstance(message, SystemMessage):
+            roles.append("system")
+
+    text = str(exc).lower()
+    if "system" in roles and (
+        "system" in text
+        or "role" in text
+        or "input should be 'user' or 'assistant'" in text
+    ):
+        return True
+
+    chat_roles = [role for role in roles if role != "system"]
+    if not chat_roles:
+        return False
+
+    has_repeated_chat_role = any(
+        left == right for left, right in zip(chat_roles, chat_roles[1:])
+    )
+    has_optional_chat_shape = (
+        has_repeated_chat_role
+        or chat_roles[0] == "assistant"
+        or chat_roles[-1] == "assistant"
+    )
+    if not has_optional_chat_shape:
+        return False
+
+    return any(
+        marker in text
+        for marker in (
+            "roles must alternate",
+            "add_generation_prompt",
+            "continue_final_message",
+            "chat template",
+            "last message is from the assistant",
+        )
+    )
+
+
 @pytest.mark.parametrize(
     "func",
     ["invoke", "ainvoke"],
@@ -115,14 +161,10 @@ async def test_chat_ai_endpoints_system_message(
         pytest.param(
             [HumanMessage(content="Hello"), HumanMessage(content="Hello")],
             id="double_human_message",
-            marks=pytest.mark.xfail(
-                reason="Known issue, messages types must alternate"
-            ),
         ),
         pytest.param(
             [AIMessage(content="Hi"), AIMessage(content="Hi")],
             id="double_ai_message",
-            marks=pytest.mark.xfail(reason="Known issue, message types must alternate"),
         ),
         pytest.param(
             [HumanMessage(content="Hello"), AIMessage(content="Hi")],
@@ -171,19 +213,19 @@ async def test_chat_ai_endpoints_system_message(
         ),
     ],
 )
-@pytest.mark.xfail(
-    reason=(
-        "not all endpoints support system messages, "
-        "repeated message types or ending with an ai message"
-    )
-)
 def test_messages(
     chat_model: str, mode: dict, system: List, exchange: List[BaseMessage]
 ) -> None:
     if not system and not exchange:
         pytest.skip("No messages to test")
     chat = ChatNVIDIA(model=chat_model, max_tokens=36, **mode)
-    response = chat.invoke(system + exchange)
+    messages = system + exchange
+    try:
+        response = chat.invoke(messages)
+    except Exception as exc:
+        if _is_known_message_shape_error(messages, exc):
+            pytest.xfail(f"Endpoint does not support this message shape: {exc}")
+        raise
     assert isinstance(response, BaseMessage)
     assert response.response_metadata["role"] == "assistant"
     assert isinstance(response.content, str)

--- a/libs/ai-endpoints/tests/unit_tests/test_chat_models.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_chat_models.py
@@ -350,6 +350,7 @@ def test_different_thinking_prefixes_for_different_models(
     "model_name",
     [
         "nvidia/nemotron-3-nano-30b-a3b",
+        "nvidia/nemotron-3.5-lightning-30b-a3b",
     ],
 )
 @pytest.mark.parametrize(
@@ -397,6 +398,7 @@ def test_param_based_thinking_mode(
     "model_name",
     [
         "nvidia/nemotron-3-nano-30b-a3b",
+        "nvidia/nemotron-3.5-lightning-30b-a3b",
     ],
 )
 @pytest.mark.parametrize(

--- a/libs/ai-endpoints/tests/unit_tests/test_structured_output.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_structured_output.py
@@ -420,13 +420,13 @@ def test_hosted_api_endpoint_openai_and_direct_fail_falls_back_to_nvext(
     assert result.rating == 5
 
 
-# --- Self-hosted NIM tests (direct -> nvext -> OpenAI) ---
+# --- Self-hosted NIM tests (OpenAI -> direct -> nvext) ---
 
 
-def test_self_hosted_direct_format_succeeds(
+def test_self_hosted_openai_format_succeeds(
     requests_mock: requests_mock.Mocker,
 ) -> None:
-    """Test self-hosted: direct format succeeds on first try."""
+    """Test self-hosted: OpenAI format succeeds on first try."""
     requests_mock.get(
         "http://my-nim:8000/v1/models",
         json={"data": [{"id": "my-model"}]},
@@ -442,13 +442,15 @@ def test_self_hosted_direct_format_succeeds(
     ).with_structured_output(Joke)
     result = llm.invoke("test")
 
-    # Should only make 1 POST call (direct format succeeds)
+    # Should only make 1 POST call (OpenAI format succeeds)
     post_calls = [req for req in requests_mock.request_history if req.method == "POST"]
     assert len(post_calls) == 1
 
-    # First call: direct format (succeeds)
+    # First call: OpenAI format (succeeds)
     body = post_calls[0].json()
-    assert "guided_json" in body
+    assert "response_format" in body
+    assert body["response_format"]["type"] == "json_schema"
+    assert "guided_json" not in body
     assert "nvext" not in body
 
     assert isinstance(result, Joke)
@@ -457,19 +459,18 @@ def test_self_hosted_direct_format_succeeds(
     assert result.rating == 5
 
 
-def test_self_hosted_direct_fails_falls_back_to_nvext(
+def test_self_hosted_openai_fails_falls_back_to_direct(
     requests_mock: requests_mock.Mocker,
 ) -> None:
-    """Test self-hosted: direct format fails, falls back to nvext format."""
+    """Test self-hosted: OpenAI format fails, falls back to direct format."""
     requests_mock.get(
         "http://my-nim:8000/v1/models",
         json={"data": [{"id": "my-model"}]},
     )
-    # First call fails (direct), second succeeds (nvext)
     requests_mock.post(
         "http://my-nim:8000/v1/chat/completions",
         [
-            {"status_code": 400, "json": {"error": "direct failed"}},
+            {"status_code": 400, "json": {"error": "openai format failed"}},
             {"json": _success_response(_JOKE_JSON)},
         ],
     )
@@ -480,16 +481,15 @@ def test_self_hosted_direct_fails_falls_back_to_nvext(
     ).with_structured_output(Joke)
     result = llm.invoke("test")
 
-    # Should make 2 POST calls: direct format (fails) + nvext format (succeeds)
     post_calls = [req for req in requests_mock.request_history if req.method == "POST"]
     assert len(post_calls) == 2, f"Expected 2 POST calls, got {len(post_calls)}"
 
-    # First call: direct format (fails)
-    assert "guided_json" in post_calls[0].json()
+    # First call: OpenAI format (fails)
+    assert "response_format" in post_calls[0].json()
+    # Second call: direct format (succeeds)
+    assert "guided_json" in post_calls[1].json()
     assert "nvext" not in post_calls[0].json()
-    # Second call: nvext format (succeeds)
-    assert "nvext" in post_calls[1].json()
-    assert "guided_json" in post_calls[1].json()["nvext"]
+    assert "nvext" not in post_calls[1].json()
 
     assert isinstance(result, Joke)
     assert result.setup == "Why did the chicken cross the road?"
@@ -497,20 +497,19 @@ def test_self_hosted_direct_fails_falls_back_to_nvext(
     assert result.rating == 5
 
 
-def test_self_hosted_fallback_to_openai_format(
+def test_self_hosted_openai_and_direct_fail_falls_back_to_nvext(
     requests_mock: requests_mock.Mocker,
 ) -> None:
-    """Test self-hosted: direct and nvext fail, falls back to OpenAI."""
+    """Test self-hosted: OpenAI and direct format fail, falls back to nvext."""
     requests_mock.get(
         "http://my-nim:8000/v1/models",
         json={"data": [{"id": "my-model"}]},
     )
-    # First two calls fail (direct, nvext), third succeeds (OpenAI)
     requests_mock.post(
         "http://my-nim:8000/v1/chat/completions",
         [
+            {"status_code": 400, "json": {"error": "openai format failed"}},
             {"status_code": 400, "json": {"error": "direct failed"}},
-            {"status_code": 400, "json": {"error": "nvext failed"}},
             {"json": _success_response(_JOKE_JSON)},
         ],
     )
@@ -524,15 +523,51 @@ def test_self_hosted_fallback_to_openai_format(
     post_calls = [req for req in requests_mock.request_history if req.method == "POST"]
     assert len(post_calls) == 3, f"Expected 3 POST calls, got {len(post_calls)}"
 
-    # First call: direct format (fails)
-    assert "guided_json" in post_calls[0].json()
-    assert "nvext" not in post_calls[0].json()
-    # Second call: nvext format (fails)
-    assert "nvext" in post_calls[1].json()
-    # Third call: OpenAI format (succeeds)
-    body = post_calls[2].json()
-    assert "response_format" in body
-    assert body["response_format"]["type"] == "json_schema"
+    # First call: OpenAI format (fails)
+    assert "response_format" in post_calls[0].json()
+    # Second call: direct format (fails)
+    assert "guided_json" in post_calls[1].json()
+    assert "nvext" not in post_calls[1].json()
+    # Third call: nvext format (succeeds)
+    assert "nvext" in post_calls[2].json()
+    assert "guided_json" in post_calls[2].json()["nvext"]
+
+    assert isinstance(result, Joke)
+    assert result.setup == "Why did the chicken cross the road?"
+    assert result.punchline == "To get to the other side"
+    assert result.rating == 5
+
+
+def test_self_hosted_unparseable_openai_response_falls_back_to_direct(
+    requests_mock: requests_mock.Mocker,
+) -> None:
+    """Test self-hosted: ignored response_format with HTTP 200 still falls back."""
+    requests_mock.get(
+        "http://my-nim:8000/v1/models",
+        json={"data": [{"id": "my-model"}]},
+    )
+    requests_mock.post(
+        "http://my-nim:8000/v1/chat/completions",
+        [
+            {"json": _success_response("not valid json")},
+            {"json": _success_response(_JOKE_JSON)},
+        ],
+    )
+
+    warnings.filterwarnings("ignore", r".*not known to support structured output.*")
+    llm = ChatNVIDIA(
+        base_url="http://my-nim:8000/v1", api_key="BOGUS"
+    ).with_structured_output(Joke)
+    result = llm.invoke("test")
+
+    post_calls = [req for req in requests_mock.request_history if req.method == "POST"]
+    assert len(post_calls) == 2, f"Expected 2 POST calls, got {len(post_calls)}"
+
+    # First call: OpenAI format returns unparseable content (parser returns None)
+    assert "response_format" in post_calls[0].json()
+    # Second call: direct format succeeds
+    assert "guided_json" in post_calls[1].json()
+    assert "nvext" not in post_calls[1].json()
 
     assert isinstance(result, Joke)
     assert result.setup == "Why did the chicken cross the road?"
@@ -573,33 +608,33 @@ def test_enum_openai_format_invoke(
     assert rf["json_schema"]["schema"]["additionalProperties"] is False
 
 
-def test_self_hosted_enum_guided_choice_succeeds(
+def test_self_hosted_enum_openai_format_succeeds(
     requests_mock: requests_mock.Mocker,
 ) -> None:
-    """Test self-hosted: enum uses guided_choice first and succeeds."""
+    """Test self-hosted: enum uses OpenAI response_format first."""
     requests_mock.get(
         "http://my-nim:8000/v1/models",
         json={"data": [{"id": "my-model"}]},
     )
     requests_mock.post(
         "http://my-nim:8000/v1/chat/completions",
-        json=_success_response("Yes it is"),
+        json=_success_response('{"choice": "Yes it is"}'),
     )
 
     warnings.filterwarnings("ignore", r".*not known to support structured output.*")
     llm = ChatNVIDIA(
         base_url="http://my-nim:8000/v1", api_key="BOGUS"
     ).with_structured_output(Choices)
-    result = llm.invoke("test")
+    with pytest.warns(UserWarning, match="Enum structured output is not guaranteed"):
+        result = llm.invoke("test")
 
-    # Should only make 1 POST call (guided_choice succeeds)
     post_calls = [req for req in requests_mock.request_history if req.method == "POST"]
     assert len(post_calls) == 1
 
-    # Verify guided_choice was used (not OpenAI format)
+    # Verify OpenAI format was used before legacy guided_choice.
     body = post_calls[0].json()
-    assert "guided_choice" in body
-    assert "response_format" not in body
+    assert "response_format" in body
+    assert "guided_choice" not in body
 
     assert isinstance(result, Choices)
     assert result == Choices.YES


### PR DESCRIPTION
## Summary

Fixes self-hosted NIM structured-output handling for newer NIM/vLLM behavior.

Recent downloadable NIMs support OpenAI-compatible `response_format`, while legacy `guided_json` / `nvext.guided_json` fields may be ignored and return free-form text with HTTP 200. This changes `ChatNVIDIA.with_structured_output()` to try `response_format` first for self-hosted NIMs as well as hosted endpoints, then fall back to the legacy formats.

Also narrows the integration `test_messages` xfail behavior so models that now support previously xfailed message shapes do not fail as XPASS.

## Changes

- Try `response_format` before `guided_json` / `nvext` for self-hosted NIM structured output.
- Keep fallback behavior for older NIMs if `response_format` fails.
- Add regression coverage for self-hosted structured-output ordering and fallback.
- Replace blanket `xfail` on `test_messages` with runtime xfail only for actual known message-shape rejections.
- Add Lightning thinking-mode unit coverage.

## Validation

- `poetry run pytest tests/unit_tests/test_structured_output.py -q`
- `poetry run pytest tests/unit_tests/test_structured_output.py tests/unit_tests/test_chat_models.py::test_different_thinking_prefixes_for_different_models tests/unit_tests/test_chat_models.py::test_param_based_thinking_mode -q`
- `poetry run pytest tests/integration_tests/test_chat_models.py --collect-only -q`