### PR TITLE
feat(ai-endpoints): add opt-in NIM usage telemetry

### DIFF
--- a/libs/ai-endpoints/README.md
+++ b/libs/ai-endpoints/README.md
@@ -52,6 +52,37 @@ To get access to the NVIDIA API Catalog, do the following:
 You can now use your key to access endpoints on the NVIDIA API Catalog.
 
 
+### Optional NVIDIA NIM usage telemetry
+
+Usage telemetry is disabled by default. To opt in for a client instance, set
+`usage_telemetry_enabled=True`:
+
+```python
+llm = ChatNVIDIA(
+    model="nvidia/nemotron-3-super-120b-a12b",
+    usage_telemetry_enabled=True,
+)
+```
+
+Alternatively, set `NVIDIA_USAGE_TELEMETRY_ENABLED=true` to provide the default
+for supported clients in the current process. An explicit constructor value
+overrides the environment setting.
+
+If explicitly enabled, the connector sends hourly aggregated, content-free usage
+metrics to NVIDIA. The aggregate includes connector and LangChain version
+buckets, a coarse operation and outcome category, an allowlisted public NIM ID
+or `unknown`, request and attempt counts, and aggregate token counts when the
+provider returns them.
+
+It does not send prompts, responses, embeddings, tool inputs or outputs, endpoint
+URLs, hostnames, IP addresses, credentials, exception text, or persistent user,
+device, installation, or session identifiers. Aggregates remain in memory only,
+are never written to disk, and apply only to NVIDIA-hosted NIM endpoints.
+Self-hosted endpoints do not emit this telemetry.
+
+For authorized UAT only, set `NVIDIA_USAGE_TELEMETRY_ENDPOINT` to the approved
+test ingestion URL. Do not redirect telemetry to an unapproved collector.
+
 ## Invoke the Core Chat Interface
 
 Use the following code to invoke the core chat interface.

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -35,6 +35,16 @@ from pydantic import (
 from requests.models import Response
 
 from langchain_nvidia_ai_endpoints._statics import MODEL_TABLE, Model, determine_model
+from langchain_nvidia_ai_endpoints._telemetry import (
+    _TokenUsage,
+    classify_error,
+    merge_token_usage,
+    record_usage,
+    token_usage,
+)
+from langchain_nvidia_ai_endpoints._telemetry import (
+    usage_telemetry_enabled as _usage_telemetry_enabled,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +108,16 @@ class _NVIDIABaseClient(BaseModel):
         if _API_KEY_VAR in os.environ
         else None,
         description="API Key for service of choice",
+    )
+
+    usage_telemetry_enabled: bool = Field(
+        default_factory=_usage_telemetry_enabled,
+        exclude=True,
+        repr=False,
+        description=(
+            "Enable content-free aggregate usage telemetry for NVIDIA-hosted NIMs. "
+            "Disabled by default."
+        ),
     )
 
     ## Generation arguments
@@ -329,6 +349,34 @@ class _NVIDIABaseClient(BaseModel):
                 "Authorization": f"Bearer {self.api_key.get_secret_value()}",
             }
         return payload
+
+    def _record_usage_success(self, value: Any) -> None:
+        try:
+            usage = value if isinstance(value, _TokenUsage) else token_usage(value)
+            record_usage(
+                enabled=self.usage_telemetry_enabled,
+                is_hosted=self.is_hosted,
+                client_name=self.cls,
+                model_name=self.mdl_name,
+                success=True,
+                usage=usage,
+            )
+        except Exception:
+            pass
+
+    def _record_usage_failure(self, error: BaseException) -> None:
+        try:
+            record_usage(
+                enabled=self.usage_telemetry_enabled,
+                is_hosted=self.is_hosted,
+                client_name=self.cls,
+                model_name=self.mdl_name,
+                success=False,
+                usage=_TokenUsage(),
+                error_category=classify_error(self.last_response, error),
+            )
+        except Exception:
+            pass
 
     ###################################################################################
     ################### Model discovery and selection #################################
@@ -609,10 +657,16 @@ class _NVIDIASyncClient(_NVIDIABaseClient):
         extra_headers: dict = {},
     ) -> Response:
         """Post to the API."""
-        response, session = self._post(
-            self.infer_url, payload, extra_headers=extra_headers
-        )
-        return self._wait(response, session)
+        try:
+            response, session = self._post(
+                self.infer_url, payload, extra_headers=extra_headers
+            )
+            response = self._wait(response, session)
+            self._record_usage_success(response)
+            return response
+        except BaseException as error:
+            self._record_usage_failure(error)
+            raise
 
     ###################################################################################
     ## Streaming interface to allow you to iterate through progressive generations ####
@@ -631,22 +685,36 @@ class _NVIDIASyncClient(_NVIDIABaseClient):
             "json": payload,
         }
 
-        response = self.get_session_fn().post(
-            stream=True,
-            **self._add_authorization(self.last_inputs),
-            timeout=self.timeout,
-        )
-        self._try_raise(response)
+        try:
+            self.last_response = response = self.get_session_fn().post(
+                stream=True,
+                **self._add_authorization(self.last_inputs),
+                timeout=self.timeout,
+            )
+            self._try_raise(response)
+        except BaseException as error:
+            self._record_usage_failure(error)
+            raise
         call: _NVIDIASyncClient = self.model_copy()
 
         def out_gen() -> Generator[dict, Any, Any]:
-            ## Good for client, since it allows self.last_inputs
-            for line in response.iter_lines():
-                if line and line.strip() != b"data: [DONE]":
-                    line = line.decode("utf-8")
-                    msg, final_line = call.postprocess(line)
-                    yield msg
-                self._try_raise(response)
+            usage = _TokenUsage()
+            completed = False
+            try:
+                for line in response.iter_lines():
+                    if line and line.strip() != b"data: [DONE]":
+                        line = line.decode("utf-8")
+                        msg, final_line = call.postprocess(line)
+                        usage = merge_token_usage(usage, token_usage(msg))
+                        yield msg
+                    self._try_raise(response)
+                completed = True
+            except BaseException as error:
+                self._record_usage_failure(error)
+                raise
+            finally:
+                if completed:
+                    self._record_usage_success(usage)
 
         return (r for r in out_gen())
 
@@ -816,15 +884,20 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
         extra_headers: dict = {},
     ) -> str:
         """Async version of `get_req`."""
-        response, session = await self._post_async(
-            self.infer_url, payload, extra_headers=extra_headers
-        )
         try:
-            response = await self._wait_async(response, session)
-            text = await response.text()
-            return text
-        finally:
-            await session.close()
+            response, session = await self._post_async(
+                self.infer_url, payload, extra_headers=extra_headers
+            )
+            try:
+                response = await self._wait_async(response, session)
+                text = await response.text()
+                self._record_usage_success(text)
+                return text
+            finally:
+                await session.close()
+        except BaseException as error:
+            self._record_usage_failure(error)
+            raise
 
     async def aget_req_stream(
         self,
@@ -842,6 +915,8 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
         }
 
         session = self.get_async_session_fn()
+        usage = _TokenUsage()
+        completed = False
         try:
             self.last_response = response = await session.post(
                 **self._add_authorization(self.last_inputs)
@@ -858,10 +933,17 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
                 if line and line != b"data: [DONE]":
                     line_str = line.decode("utf-8")
                     msg, final_line = call.postprocess(line_str)
+                    usage = merge_token_usage(usage, token_usage(msg))
                     yield msg
                 await self._try_raise_async(response)
+            completed = True
+        except BaseException as error:
+            self._record_usage_failure(error)
+            raise
         finally:
             await session.close()
+            if completed:
+                self._record_usage_success(usage)
 
 
 def _build_clients(

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_telemetry.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_telemetry.py
@@ -1,0 +1,557 @@
+"""Explicitly enabled, content-free aggregate usage telemetry."""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import importlib.metadata
+import os
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Mapping, Optional
+from uuid import uuid4
+
+import aiohttp
+import requests
+
+from langchain_nvidia_ai_endpoints._statics import MODEL_TABLE
+from langchain_nvidia_ai_endpoints._version import __version__
+
+_CLIENT_ID = "623344073512268"
+_EVENT_SCHEMA_VERSION = "1.0"
+_REGISTRY_SCHEMA_VERSION = "0.1"
+_EVENT_PROTOCOL = "1.6"
+_EVENT_NAME = "nim_client_usage"
+_CONNECTOR = "langchain-nvidia-ai-endpoints"
+_DEFAULT_ENDPOINT = "https://events.telemetry.data.nvidia.com/v1.1/events/json"
+_UAT_ENDPOINT = "https://events.telemetry.data-uat.nvidia.com/v1.1/events/json"
+_ALLOWED_ENDPOINTS = frozenset({_DEFAULT_ENDPOINT, _UAT_ENDPOINT})
+_ENABLED_ENV = "NVIDIA_USAGE_TELEMETRY_ENABLED"
+_ENDPOINT_ENV = "NVIDIA_USAGE_TELEMETRY_ENDPOINT"
+_MAX_COUNT = 2**31 - 1
+_MAX_TOKEN_SUM = 2**63 - 1
+_MAX_BUCKETS = 256
+
+_OPERATION_BY_CLIENT = {
+    "ChatNVIDIA": "chat",
+    "NVIDIAEmbeddings": "embedding",
+    "NVIDIARerank": "rerank",
+    "NVIDIA": "completion",
+}
+
+_APPROVED_MODEL_LOOKUP: dict[str, str] = {}
+for _approved_model in MODEL_TABLE.values():
+    _APPROVED_MODEL_LOOKUP[_approved_model.id] = _approved_model.id
+    for _alias in _approved_model.aliases or ():
+        _APPROVED_MODEL_LOOKUP[_alias] = _approved_model.id
+
+
+@dataclass(frozen=True)
+class _UsageKey:
+    window_start: str
+    connector_version: str
+    framework_version: str
+    operation: str
+    model_family: str
+    nim_id: str
+    error_category: str
+
+
+@dataclass
+class _UsageAggregate:
+    success_count: int = 0
+    failure_count: int = 0
+    request_count: int = 0
+    attempt_count: int = 0
+    input_token_sum: int = 0
+    output_token_sum: int = 0
+    missing_token_count: int = 0
+
+    def record(
+        self,
+        *,
+        success: bool,
+        input_tokens: int,
+        output_tokens: int,
+        tokens_missing: bool,
+    ) -> None:
+        self.request_count = min(_MAX_COUNT, self.request_count + 1)
+        self.attempt_count = min(_MAX_COUNT, self.attempt_count + 1)
+        if success:
+            self.success_count = min(_MAX_COUNT, self.success_count + 1)
+        else:
+            self.failure_count = min(_MAX_COUNT, self.failure_count + 1)
+        self.input_token_sum = min(
+            _MAX_TOKEN_SUM, self.input_token_sum + max(0, input_tokens)
+        )
+        self.output_token_sum = min(
+            _MAX_TOKEN_SUM, self.output_token_sum + max(0, output_tokens)
+        )
+        if tokens_missing:
+            self.missing_token_count = min(_MAX_COUNT, self.missing_token_count + 1)
+
+
+@dataclass(frozen=True)
+class _TokenUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    found: bool = False
+
+
+def usage_telemetry_enabled(value: Optional[bool] = None) -> bool:
+    """Return an explicit constructor setting or the default-off environment setting."""
+
+    if value is not None:
+        return value
+    return os.getenv(_ENABLED_ENV, "").strip().casefold() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def operation_for_client(client_name: str) -> str:
+    """Map a public client class to the approved coarse operation category."""
+
+    for prefix, operation in _OPERATION_BY_CLIENT.items():
+        if client_name.startswith(prefix):
+            return operation
+    return "other"
+
+
+def canonical_model_identity(model_name: Optional[str]) -> tuple[str, str]:
+    """Return a canonical allowlisted NIM ID and approved model-family bucket."""
+
+    canonical = _APPROVED_MODEL_LOOKUP.get(str(model_name or ""), "unknown")
+    if canonical == "unknown":
+        return "unknown", "unknown"
+    lowered = canonical.casefold()
+    if "nemotron" in lowered:
+        family = "nemotron"
+    elif "mixtral" in lowered:
+        family = "mixtral"
+    elif "mistral" in lowered:
+        family = "mistral"
+    elif "llama" in lowered:
+        family = "llama"
+    elif "gemma" in lowered:
+        family = "gemma"
+    elif "qwen" in lowered:
+        family = "qwen"
+    else:
+        family = "unknown"
+    return canonical, family
+
+
+def token_usage(value: Any) -> _TokenUsage:
+    """Extract only aggregate token counters from a known usage object."""
+
+    payload: Any = value
+    if isinstance(value, requests.Response):
+        try:
+            payload = value.json()
+        except (requests.JSONDecodeError, ValueError):
+            return _TokenUsage()
+    elif isinstance(value, str):
+        try:
+            import json
+
+            payload = json.loads(value)
+        except (TypeError, ValueError):
+            return _TokenUsage()
+    if not isinstance(payload, Mapping):
+        return _TokenUsage()
+    usage = payload.get("usage") or payload.get("usage_metadata")
+    if not isinstance(usage, Mapping):
+        return _TokenUsage()
+    input_tokens = _nonnegative_int(
+        usage.get("prompt_tokens")
+        if "prompt_tokens" in usage
+        else usage.get("input_tokens", usage.get("input_token_count"))
+    )
+    output_tokens = _nonnegative_int(
+        usage.get("completion_tokens")
+        if "completion_tokens" in usage
+        else usage.get("output_tokens", usage.get("output_token_count"))
+    )
+    found = any(
+        key in usage
+        for key in (
+            "prompt_tokens",
+            "input_tokens",
+            "input_token_count",
+            "completion_tokens",
+            "output_tokens",
+            "output_token_count",
+        )
+    )
+    return _TokenUsage(input_tokens, output_tokens, found)
+
+
+def merge_token_usage(current: _TokenUsage, candidate: _TokenUsage) -> _TokenUsage:
+    """Keep the latest cumulative usage counters observed in a stream."""
+
+    return candidate if candidate.found else current
+
+
+def classify_error(response: Any, error: BaseException) -> str:
+    """Map an error to an approved coarse category without retaining its text."""
+
+    status = getattr(response, "status_code", None)
+    if status is None:
+        status = getattr(response, "status", None)
+    if status == 401:
+        return "authentication"
+    if status == 403:
+        return "authorization"
+    if status == 408:
+        return "timeout"
+    if status == 429:
+        return "rate_limited"
+    if isinstance(status, int) and 400 <= status < 500:
+        return "provider_4xx"
+    if isinstance(status, int) and status >= 500:
+        return "provider_5xx"
+    if isinstance(error, (asyncio.CancelledError, GeneratorExit, KeyboardInterrupt)):
+        return "cancelled"
+    if isinstance(
+        error,
+        (
+            TimeoutError,
+            requests.exceptions.Timeout,
+            asyncio.TimeoutError,
+        ),
+    ):
+        return "timeout"
+    if isinstance(
+        error,
+        (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.RequestException,
+            aiohttp.ClientError,
+        ),
+    ):
+        return "network"
+    if isinstance(error, (TypeError, ValueError)):
+        return "client_validation"
+    return "unknown"
+
+
+class _UsageTelemetry:
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        post: Callable[[str, dict[str, Any]], None],
+        now: Callable[[], datetime],
+        start_worker: bool = True,
+        max_buckets: int = _MAX_BUCKETS,
+    ) -> None:
+        self._endpoint = endpoint
+        self._post = post
+        self._now = now
+        self._start_worker = start_worker
+        self._max_buckets = max(1, max_buckets)
+        self._aggregates: dict[_UsageKey, _UsageAggregate] = {}
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._wake = threading.Event()
+        self._closed = False
+
+    def record(
+        self,
+        *,
+        client_name: str,
+        model_name: Optional[str],
+        success: bool,
+        usage: _TokenUsage,
+        error_category: str = "none",
+    ) -> None:
+        now = self._now().astimezone(timezone.utc)
+        canonical_id, family = canonical_model_identity(model_name)
+        category = "none" if success else error_category
+        key = _UsageKey(
+            window_start=_hour_start(now),
+            connector_version=_version_bucket(__version__),
+            framework_version=_framework_version_bucket(),
+            operation=operation_for_client(client_name),
+            model_family=family,
+            nim_id=canonical_id,
+            error_category=category,
+        )
+        with self._lock:
+            if self._closed:
+                return
+            aggregate = self._aggregates.get(key)
+            if aggregate is None:
+                if len(self._aggregates) >= self._max_buckets:
+                    return
+                aggregate = self._aggregates[key] = _UsageAggregate()
+            aggregate.record(
+                success=success,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                tokens_missing=not usage.found,
+            )
+            if self._start_worker and self._thread is None:
+                self._thread = threading.Thread(
+                    target=self._run,
+                    name="nvidia-usage-telemetry",
+                    daemon=True,
+                )
+                self._thread.start()
+        if self._start_worker:
+            self._wake.set()
+
+    def flush(self, *, include_current: bool) -> int:
+        now = self._now().astimezone(timezone.utc)
+        current_hour = _hour_start(now)
+        with self._lock:
+            ready = [
+                (key, aggregate)
+                for key, aggregate in self._aggregates.items()
+                if include_current or key.window_start < current_hour
+            ]
+            for key, _ in ready:
+                del self._aggregates[key]
+        if not ready:
+            return 0
+        batch_id = str(uuid4())
+        events = [
+            _event_payload(key, aggregate, batch_id=batch_id)
+            for key, aggregate in ready
+        ]
+        self._post(self._endpoint, _transport_envelope(events, now=now))
+        return len(events)
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+        self._stop.set()
+        self._wake.set()
+        self.flush(include_current=True)
+        thread = self._thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=0.1)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self._wake.wait(_seconds_until_next_hour(self._now()))
+            self._wake.clear()
+            if not self._stop.is_set():
+                self.flush(include_current=False)
+
+
+_STATE: Optional[_UsageTelemetry] = None
+_STATE_LOCK = threading.Lock()
+
+
+def record_usage(
+    *,
+    enabled: bool,
+    is_hosted: bool,
+    client_name: str,
+    model_name: Optional[str],
+    success: bool,
+    usage: _TokenUsage,
+    error_category: str = "none",
+) -> None:
+    """Record one logical request without retaining request or response content."""
+
+    if not enabled or not is_hosted:
+        return
+    endpoint = _configured_endpoint()
+    if endpoint is None:
+        return
+    _get_state(endpoint).record(
+        client_name=client_name,
+        model_name=model_name,
+        success=success,
+        usage=usage,
+        error_category=error_category,
+    )
+
+
+def flush_usage_telemetry() -> int:
+    """Flush the current in-memory aggregate, primarily for controlled shutdown."""
+
+    state = _STATE
+    return state.flush(include_current=True) if state is not None else 0
+
+
+def _get_state(endpoint: str) -> _UsageTelemetry:
+    global _STATE
+    if _STATE is None:
+        with _STATE_LOCK:
+            if _STATE is None:
+                _STATE = _UsageTelemetry(
+                    endpoint=endpoint,
+                    post=_post_envelope,
+                    now=lambda: datetime.now(timezone.utc),
+                )
+    return _STATE
+
+
+def _configured_endpoint() -> Optional[str]:
+    endpoint = os.getenv(_ENDPOINT_ENV, _DEFAULT_ENDPOINT).strip()
+    return endpoint if endpoint in _ALLOWED_ENDPOINTS else None
+
+
+def _close_state() -> None:
+    state = _STATE
+    if state is not None:
+        state.close()
+
+
+def _reset_usage_telemetry_for_tests() -> None:
+    global _STATE
+    state = _STATE
+    _STATE = None
+    if state is not None:
+        state.close()
+
+
+def _post_envelope(endpoint: str, payload: dict[str, Any]) -> None:
+    timeout = _bounded_float(os.getenv("NVIDIA_USAGE_TELEMETRY_TIMEOUT_SECONDS"), 2.0)
+    for attempt in range(3):
+        try:
+            response = requests.post(
+                endpoint,
+                json=payload,
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/json;charset=utf-8",
+                    "X-Event-Protocol": _EVENT_PROTOCOL,
+                },
+                timeout=timeout,
+            )
+        except requests.exceptions.RequestException:
+            if attempt < 2:
+                time.sleep(0.1 * (2**attempt))
+            continue
+        if response.ok:
+            return
+        if response.status_code not in {408, 429} and response.status_code < 500:
+            return
+        if attempt < 2:
+            time.sleep(0.1 * (2**attempt))
+
+
+def _event_payload(
+    key: _UsageKey, aggregate: _UsageAggregate, *, batch_id: str
+) -> dict[str, Any]:
+    return {
+        "ts": _iso_timestamp(datetime.now(timezone.utc)),
+        "name": _EVENT_NAME,
+        "parameters": {
+            "eventSchemaVersion": _EVENT_SCHEMA_VERSION,
+            "windowStart": key.window_start,
+            "connector": _CONNECTOR,
+            "connectorVersion": key.connector_version,
+            "framework": "langchain",
+            "frameworkVersion": key.framework_version,
+            "operation": key.operation,
+            "modelFamily": key.model_family,
+            "nimId": key.nim_id,
+            "successCount": aggregate.success_count,
+            "failureCount": aggregate.failure_count,
+            "requestCount": aggregate.request_count,
+            "attemptCount": aggregate.attempt_count,
+            "inputTokenSum": aggregate.input_token_sum,
+            "outputTokenSum": aggregate.output_token_sum,
+            "missingTokenCount": aggregate.missing_token_count,
+            "errorCategory": key.error_category,
+            "batchId": batch_id,
+        },
+    }
+
+
+def _transport_envelope(
+    events: list[dict[str, Any]], *, now: datetime
+) -> dict[str, Any]:
+    return {
+        "clientId": _CLIENT_ID,
+        "eventSchemaVer": _REGISTRY_SCHEMA_VERSION,
+        "eventProtocol": _EVENT_PROTOCOL,
+        "sentTs": _iso_timestamp(now),
+        "clientVer": "1.0.0.0",
+        "integrationId": "undefined",
+        "clientType": "Native",
+        "clientVariant": "Release",
+        "browserType": "undefined",
+        "userId": "undefined",
+        "externalUserId": "undefined",
+        "idpId": "undefined",
+        "sessionId": "undefined",
+        "eventSysVer": "1.0.0.0",
+        "deviceId": "undefined",
+        "cpuArchitecture": "undefined",
+        "deviceOS": "undefined",
+        "deviceOSVersion": "undefined",
+        "deviceType": "undefined",
+        "deviceMake": "undefined",
+        "deviceModel": "undefined",
+        "productName": "undefined",
+        "productVersion": "undefined",
+        "gdprTechOptIn": "None",
+        "gdprBehOptIn": "None",
+        "gdprFuncOptIn": "Full",
+        "deviceGdprTechOptIn": "None",
+        "deviceGdprBehOptIn": "None",
+        "deviceGdprFuncOptIn": "None",
+        "events": events,
+    }
+
+
+def _framework_version_bucket() -> str:
+    try:
+        return _version_bucket(importlib.metadata.version("langchain-core"))
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _version_bucket(value: str) -> str:
+    parts = value.strip().split(".")
+    if len(parts) < 2 or not parts[0].isdigit() or not parts[1].isdigit():
+        return "unknown"
+    return f"{int(parts[0])}.{int(parts[1])}"
+
+
+def _hour_start(value: datetime) -> str:
+    value = value.astimezone(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    return value.strftime("%Y-%m-%dT%H:00:00Z")
+
+
+def _seconds_until_next_hour(value: datetime) -> float:
+    value = value.astimezone(timezone.utc)
+    next_hour = value.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    return max(0.1, (next_hour - value).total_seconds())
+
+
+def _iso_timestamp(value: datetime) -> str:
+    value = value.astimezone(timezone.utc)
+    return value.strftime("%Y-%m-%dT%H:%M:%S.") + f"{value.microsecond // 1000:03d}Z"
+
+
+def _nonnegative_int(value: Any) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bounded_float(value: Optional[str], default: float) -> float:
+    try:
+        parsed = float(value) if value is not None else default
+    except ValueError:
+        parsed = default
+    return min(10.0, max(0.1, parsed))
+
+
+atexit.register(_close_state)

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -382,6 +382,15 @@ class ChatNVIDIA(BaseChatModel):
         description="Default headers merged into all requests.",
     )
 
+    usage_telemetry_enabled: Optional[bool] = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Enable content-free aggregate usage telemetry. Disabled by default."
+        ),
+    )
+
     model_kwargs: Dict[str, Any] = Field(
         default_factory=dict,
         description=(
@@ -441,6 +450,10 @@ class ChatNVIDIA(BaseChatModel):
             seed: A seed for deterministic results.
             stop: A string or list of strings specifying stop sequences.
             default_headers: Default headers merged into all requests.
+            usage_telemetry_enabled: Enable content-free hourly usage aggregates for
+                NVIDIA-hosted NIMs. Disabled by default. The
+                `NVIDIA_USAGE_TELEMETRY_ENABLED` environment variable provides the
+                default when this argument is omitted.
             **kwargs: Additional parameters passed to the underlying client.
 
         The recommended way to provide the API key is through the `NVIDIA_API_KEY`
@@ -516,6 +529,11 @@ class ChatNVIDIA(BaseChatModel):
             cls="ChatNVIDIA",
             verify_ssl=verify_ssl,
             **({"timeout": timeout} if timeout is not None else {}),
+            **(
+                {"usage_telemetry_enabled": self.usage_telemetry_enabled}
+                if self.usage_telemetry_enabled is not None
+                else {}
+            ),
         )
         # todo: only store the model in one place
         # the model may be updated to a newer name during initialization

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
@@ -72,6 +72,15 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
         description="Default headers merged into all requests.",
     )
 
+    usage_telemetry_enabled: Optional[bool] = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Enable content-free aggregate usage telemetry. Disabled by default."
+        ),
+    )
+
     def __init__(
         self,
         *,
@@ -103,6 +112,8 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
                 an error if an input is too long.
             dimensions: The number of dimensions for the embeddings. This
                 parameter is not supported by all models.
+            usage_telemetry_enabled: Enable content-free hourly usage aggregates for
+                NVIDIA-hosted NIMs. Disabled by default.
             **kwargs: Additional parameters passed to the underlying client.
 
         The recommended way to provide the API key is through the `NVIDIA_API_KEY`
@@ -148,6 +159,11 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
             infer_path="{base_url}/embeddings",
             cls=self.__class__.__name__,
             verify_ssl=verify_ssl,
+            **(
+                {"usage_telemetry_enabled": self.usage_telemetry_enabled}
+                if self.usage_telemetry_enabled is not None
+                else {}
+            ),
         )
 
         # todo: only store the model in one place

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/llm.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/llm.py
@@ -43,6 +43,15 @@ class NVIDIA(LLM):
 
     model: Optional[str] = Field(None, description="The model to use for completions.")
 
+    usage_telemetry_enabled: Optional[bool] = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Enable content-free aggregate usage telemetry. Disabled by default."
+        ),
+    )
+
     _init_args: Dict[str, Any] = PrivateAttr()
     """Stashed arguments given to the constructor that can be passed to
     the Completions API endpoint."""
@@ -100,6 +109,8 @@ class NVIDIA(LLM):
         Args:
             nvidia_api_key: The API key to use for connecting to the hosted NIM.
             api_key: Alternative to `nvidia_api_key`.
+            usage_telemetry_enabled: Enable content-free hourly usage aggregates for
+                NVIDIA-hosted NIMs. Disabled by default.
             **kwargs: Additional parameters passed to the underlying client.
 
         The recommended way to provide the API key is through the `NVIDIA_API_KEY`
@@ -138,6 +149,11 @@ class NVIDIA(LLM):
             infer_path="{base_url}/completions",
             cls=self.__class__.__name__,
             verify_ssl=verify_ssl,
+            **(
+                {"usage_telemetry_enabled": self.usage_telemetry_enabled}
+                if self.usage_telemetry_enabled is not None
+                else {}
+            ),
         )
         # todo: only store the model in one place
         # the model may be updated to a newer name during initialization
@@ -151,6 +167,7 @@ class NVIDIA(LLM):
             "model",
             "nvidia_base_url",
             "base_url",
+            "usage_telemetry_enabled",
         ]:
             if key in kwargs:
                 del kwargs[key]

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
@@ -72,6 +72,15 @@ class NVIDIARerank(BaseDocumentCompressor):
         description="Default headers merged into all requests.",
     )
 
+    usage_telemetry_enabled: Optional[bool] = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Enable content-free aggregate usage telemetry. Disabled by default."
+        ),
+    )
+
     extra_headers: dict = Field(
         default_factory=dict,
         description="Deprecated: Use 'default_headers' instead. "
@@ -96,6 +105,8 @@ class NVIDIARerank(BaseDocumentCompressor):
         Args:
             nvidia_api_key: The API key to use for connecting to the hosted NIM.
             api_key: Alternative to `nvidia_api_key`.
+            usage_telemetry_enabled: Enable content-free hourly usage aggregates for
+                NVIDIA-hosted NIMs. Disabled by default.
             **kwargs: Additional parameters passed to the underlying client.
 
         The recommended way to provide the API key is through the `NVIDIA_API_KEY`
@@ -218,6 +229,11 @@ class NVIDIARerank(BaseDocumentCompressor):
             infer_path="{base_url}/ranking",
             cls=self.__class__.__name__,
             verify_ssl=verify_ssl,
+            **(
+                {"usage_telemetry_enabled": self.usage_telemetry_enabled}
+                if self.usage_telemetry_enabled is not None
+                else {}
+            ),
         )
 
         # todo: only store the model in one place

--- a/libs/ai-endpoints/tests/data/nim_client_usage_schema.json
+++ b/libs/ai-endpoints/tests/data/nim_client_usage_schema.json
@@ -1,0 +1,249 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaMeta": {
+    "schemaVersion": "0.1",
+    "clientId": "623344073512268",
+    "clientName": "NIM_OSS",
+    "definitionVersion": "1.0",
+    "personalization": ""
+  },
+  "description": "Privacy-safe aggregate usage telemetry for NVIDIA NIM integrations in supported open-source connector libraries.",
+  "definitions": {
+    "types": {
+      "NimFrameworkEnum": {
+        "type": "string",
+        "description": "Closed framework ID; unknown is used when an approved mapping is unavailable.",
+        "enum": [
+          "langchain",
+          "unknown"
+        ]
+      },
+      "NimOperationEnum": {
+        "type": "string",
+        "description": "Coarse logical operation category.",
+        "enum": [
+          "chat",
+          "completion",
+          "embedding",
+          "rerank",
+          "retrieval",
+          "other"
+        ]
+      },
+      "NimModelFamilyEnum": {
+        "type": "string",
+        "description": "Versioned, approved model-family classification; never a raw model name or endpoint value.",
+        "enum": [
+          "llama",
+          "mistral",
+          "mixtral",
+          "gemma",
+          "qwen",
+          "nemotron",
+          "unknown"
+        ]
+      },
+      "NimErrorCategoryEnum": {
+        "type": "string",
+        "description": "Coarse final logical outcome category; transient retry errors are not reported.",
+        "enum": [
+          "none",
+          "authentication",
+          "authorization",
+          "rate_limited",
+          "timeout",
+          "network",
+          "provider_4xx",
+          "provider_5xx",
+          "client_validation",
+          "cancelled",
+          "unknown"
+        ]
+      },
+      "NimVersionBucket": {
+        "type": "string",
+        "description": "Major.minor version bucket without package, prerelease, build, or patch identifiers.",
+        "maxLength": 32,
+        "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+      },
+      "NimFrameworkVersionBucket": {
+        "type": "string",
+        "description": "Major.minor framework version bucket or unknown when an approved mapping is unavailable.",
+        "maxLength": 32,
+        "pattern": "^(unknown|(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*))$"
+      },
+      "NimUtcHour": {
+        "type": "string",
+        "description": "UTC aggregation window rounded to the hour with no per-invocation timestamp.",
+        "maxLength": 20,
+        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):00:00Z$"
+      },
+      "NimBatchId": {
+        "type": "string",
+        "description": "Ephemeral random UUIDv4 generated once per transmission batch for bounded deduplication; never persisted, reused, or joined to identity-bearing data.",
+        "maxLength": 36,
+        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+      },
+      "NimAggregateCount": {
+        "type": "integer",
+        "description": "Bounded nonnegative aggregate count.",
+        "minimum": 0,
+        "maximum": 2147483647
+      },
+      "NimPositiveAggregateCount": {
+        "type": "integer",
+        "description": "Bounded positive aggregate count.",
+        "minimum": 1,
+        "maximum": 2147483647
+      },
+      "NimTokenSum": {
+        "type": "integer",
+        "description": "Bounded nonnegative aggregate token sum; collection remains subject to privacy approval.",
+        "minimum": 0,
+        "maximum": 9223372036854775807
+      }
+    },
+    "events": {
+      "nim_client_usage": {
+        "description": "Hourly aggregate for explicitly enabled NIM OSS connector usage. Contains no content, endpoint details, arbitrary strings, or durable user, device, installation, or session identifiers.",
+        "type": "object",
+        "eventMeta": {
+          "service": "telemetry",
+          "gdpr": {
+            "category": "functional",
+            "description": "Content-free, identity-free aggregate metadata with ephemeral transmission-batch deduplication.",
+            "personalization": ""
+          }
+        },
+        "properties": {
+          "eventSchemaVersion": {
+            "type": "string",
+            "description": "Version of the nim_client_usage event contract, independent of the registry schema version.",
+            "const": "1.0"
+          },
+          "windowStart": {
+            "$ref": "#/definitions/types/NimUtcHour"
+          },
+          "connector": {
+            "type": "string",
+            "description": "The only connector in the approval-gated MVP.",
+            "const": "langchain-nvidia-ai-endpoints"
+          },
+          "connectorVersion": {
+            "$ref": "#/definitions/types/NimVersionBucket"
+          },
+          "framework": {
+            "$ref": "#/definitions/types/NimFrameworkEnum"
+          },
+          "frameworkVersion": {
+            "$ref": "#/definitions/types/NimFrameworkVersionBucket"
+          },
+          "operation": {
+            "$ref": "#/definitions/types/NimOperationEnum"
+          },
+          "modelFamily": {
+            "$ref": "#/definitions/types/NimModelFamilyEnum"
+          },
+          "nimId": {
+            "type": "string",
+            "description": "Canonical public NIM identifier emitted only after an exact match to the connector's versioned allowlist; raw and unrecognized model inputs map to 'unknown'.",
+            "maxLength": 192,
+            "pattern": "^(unknown|[A-Za-z0-9][A-Za-z0-9._-]{0,63}/[A-Za-z0-9][A-Za-z0-9._-]{0,126})$"
+          },
+          "successCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "failureCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "requestCount": {
+            "$ref": "#/definitions/types/NimPositiveAggregateCount"
+          },
+          "attemptCount": {
+            "$ref": "#/definitions/types/NimPositiveAggregateCount"
+          },
+          "inputTokenSum": {
+            "$ref": "#/definitions/types/NimTokenSum"
+          },
+          "outputTokenSum": {
+            "$ref": "#/definitions/types/NimTokenSum"
+          },
+          "missingTokenCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "errorCategory": {
+            "$ref": "#/definitions/types/NimErrorCategoryEnum"
+          },
+          "batchId": {
+            "$ref": "#/definitions/types/NimBatchId"
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "errorCategory": {
+                  "const": "none"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "failureCount": {
+                  "const": 0
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "errorCategory": {
+                  "not": {
+                    "const": "none"
+                  }
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "successCount": {
+                  "const": 0
+                },
+                "failureCount": {
+                  "minimum": 1
+                }
+              }
+            }
+          }
+        ],
+        "additionalProperties": false,
+        "required": [
+          "eventSchemaVersion",
+          "windowStart",
+          "connector",
+          "connectorVersion",
+          "framework",
+          "frameworkVersion",
+          "operation",
+          "modelFamily",
+          "nimId",
+          "successCount",
+          "failureCount",
+          "requestCount",
+          "attemptCount",
+          "inputTokenSum",
+          "outputTokenSum",
+          "missingTokenCount",
+          "errorCategory",
+          "batchId"
+        ]
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/definitions/events/nim_client_usage"
+    }
+  ]
+}

--- a/libs/ai-endpoints/tests/unit_tests/test_usage_telemetry.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_usage_telemetry.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, AsyncGenerator, Generator, cast
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+import requests
+
+from langchain_nvidia_ai_endpoints._common import (
+    _NVIDIAAsyncClient,
+    _NVIDIASyncClient,
+)
+from langchain_nvidia_ai_endpoints._telemetry import (
+    _post_envelope,
+    _TokenUsage,
+    _UsageTelemetry,
+    canonical_model_identity,
+    classify_error,
+    flush_usage_telemetry,
+    merge_token_usage,
+    operation_for_client,
+    record_usage,
+    token_usage,
+    usage_telemetry_enabled,
+)
+from langchain_nvidia_ai_endpoints.chat_models import ChatNVIDIA
+from langchain_nvidia_ai_endpoints.embeddings import NVIDIAEmbeddings
+from langchain_nvidia_ai_endpoints.llm import NVIDIA
+from langchain_nvidia_ai_endpoints.reranking import NVIDIARerank
+
+
+@pytest.fixture(autouse=True)
+def reset_global_telemetry() -> Generator[None, None, None]:
+    from langchain_nvidia_ai_endpoints import _telemetry
+
+    _telemetry._reset_usage_telemetry_for_tests()
+    yield
+    _telemetry._reset_usage_telemetry_for_tests()
+
+
+def _sync_client(**overrides: Any) -> _NVIDIASyncClient:
+    values: dict[str, Any] = {
+        "default_hosted_model_name": "nvidia/nemotron-3.5-lightning-30b-a3b",
+        "mdl_name": "nvidia/nemotron-3.5-lightning-30b-a3b",
+        "model": None,
+        "is_hosted": True,
+        "cls": "ChatNVIDIA",
+        "infer_path": "{base_url}/chat/completions",
+        "usage_telemetry_enabled": True,
+    }
+    values.update(overrides)
+    return _NVIDIASyncClient(**values)
+
+
+def _async_client(**overrides: Any) -> _NVIDIAAsyncClient:
+    values: dict[str, Any] = {
+        "default_hosted_model_name": "nvidia/nemotron-3.5-lightning-30b-a3b",
+        "mdl_name": "nvidia/nemotron-3.5-lightning-30b-a3b",
+        "model": None,
+        "is_hosted": True,
+        "cls": "ChatNVIDIA",
+        "infer_path": "{base_url}/chat/completions",
+        "usage_telemetry_enabled": True,
+    }
+    values.update(overrides)
+    return _NVIDIAAsyncClient(**values)
+
+
+def _response(status: int = 200, payload: dict | None = None) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status
+    response._content = json.dumps(payload or {}).encode("utf-8")
+    return response
+
+
+def test_usage_telemetry_is_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NVIDIA_USAGE_TELEMETRY_ENABLED", raising=False)
+    assert usage_telemetry_enabled() is False
+    assert usage_telemetry_enabled(False) is False
+    assert usage_telemetry_enabled(True) is True
+
+    monkeypatch.setenv("NVIDIA_USAGE_TELEMETRY_ENABLED", "true")
+    assert usage_telemetry_enabled() is True
+
+
+def test_canonical_model_identity_uses_versioned_static_allowlist() -> None:
+    assert canonical_model_identity("nvidia/nemotron-3.5-lightning-30b-a3b") == (
+        "nvidia/nemotron-3.5-lightning-30b-a3b",
+        "nemotron",
+    )
+    assert canonical_model_identity("ai-mixtral-8x7b-instruct") == (
+        "mistralai/mixtral-8x7b-instruct-v0.1",
+        "mixtral",
+    )
+    assert canonical_model_identity("private/raw-model-name") == ("unknown", "unknown")
+
+
+def test_operation_mapping_is_closed() -> None:
+    assert operation_for_client("ChatNVIDIA") == "chat"
+    assert operation_for_client("ChatNVIDIACustom") == "chat"
+    assert operation_for_client("NVIDIA") == "completion"
+    assert operation_for_client("NVIDIAEmbeddings") == "embedding"
+    assert operation_for_client("NVIDIARerank") == "rerank"
+    assert operation_for_client("UnrecognizedClient") == "other"
+
+
+def test_token_usage_reads_only_known_aggregate_fields() -> None:
+    usage = token_usage(
+        {
+            "choices": [{"message": {"content": "private response"}}],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 7},
+        }
+    )
+    assert usage == _TokenUsage(input_tokens=12, output_tokens=7, found=True)
+    assert merge_token_usage(_TokenUsage(), usage) == usage
+    assert token_usage({"usage": {}}) == _TokenUsage()
+
+
+def test_error_classification_uses_status_and_exception_type() -> None:
+    assert (
+        classify_error(SimpleNamespace(status_code=401), Exception("secret"))
+        == "authentication"
+    )
+    assert (
+        classify_error(SimpleNamespace(status_code=403), Exception("secret"))
+        == "authorization"
+    )
+    assert (
+        classify_error(SimpleNamespace(status_code=429), Exception("secret"))
+        == "rate_limited"
+    )
+    assert (
+        classify_error(SimpleNamespace(status_code=503), Exception("secret"))
+        == "provider_5xx"
+    )
+    assert classify_error(None, TimeoutError("secret")) == "timeout"
+    assert classify_error(None, requests.ConnectionError("secret")) == "network"
+    assert classify_error(None, ValueError("private prompt")) == "client_validation"
+
+
+def test_aggregate_flush_matches_schema_and_has_no_identity_values() -> None:
+    captured: list[dict] = []
+    fixed_now = datetime(2026, 8, 28, 14, 30, tzinfo=timezone.utc)
+    state = _UsageTelemetry(
+        endpoint="https://events.example.test/v1.1/events/json",
+        post=lambda endpoint, payload: captured.append(payload),
+        now=lambda: fixed_now,
+        start_worker=False,
+    )
+    state.record(
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(100, 50, True),
+    )
+    state.record(
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(20, 10, True),
+    )
+    state.record(
+        client_name="ChatNVIDIA",
+        model_name="private/model",
+        success=False,
+        usage=_TokenUsage(),
+        error_category="authorization",
+    )
+
+    assert state.flush(include_current=True) == 2
+    assert len(captured) == 1
+    envelope = captured[0]
+    assert envelope["clientId"] == "623344073512268"
+    assert envelope["eventSchemaVer"] == "0.1"
+    for field in ("userId", "externalUserId", "idpId", "sessionId", "deviceId"):
+        assert envelope[field] == "undefined"
+
+    events = envelope["events"]
+    assert {event["name"] for event in events} == {"nim_client_usage"}
+    assert len({event["parameters"]["batchId"] for event in events}) == 1
+    success = next(
+        event["parameters"]
+        for event in events
+        if event["parameters"]["errorCategory"] == "none"
+    )
+    assert success["requestCount"] == 2
+    assert success["successCount"] == 2
+    assert success["failureCount"] == 0
+    assert success["inputTokenSum"] == 120
+    assert success["outputTokenSum"] == 60
+    failure = next(
+        event["parameters"]
+        for event in events
+        if event["parameters"]["errorCategory"] == "authorization"
+    )
+    assert failure["nimId"] == "unknown"
+    assert failure["modelFamily"] == "unknown"
+    assert failure["successCount"] == 0
+    assert failure["failureCount"] == 1
+    assert failure["missingTokenCount"] == 1
+
+    schema = json.loads(
+        (
+            Path(__file__).parents[1] / "data" / "nim_client_usage_schema.json"
+        ).read_text()
+    )
+    required = set(schema["definitions"]["events"]["nim_client_usage"]["required"])
+    for event in events:
+        assert set(event["parameters"]) == required
+    serialized = json.dumps(envelope)
+    for forbidden in (
+        "private prompt",
+        "private response",
+        "endpoint_url",
+        "hostname",
+        "exception",
+        "credential",
+    ):
+        assert forbidden not in serialized
+
+
+def test_aggregate_bucket_count_is_bounded() -> None:
+    captured: list[dict] = []
+    state = _UsageTelemetry(
+        endpoint="https://events.example.test/v1.1/events/json",
+        post=lambda endpoint, payload: captured.append(payload),
+        now=lambda: datetime(2026, 8, 28, 14, 30, tzinfo=timezone.utc),
+        start_worker=False,
+        max_buckets=1,
+    )
+    state.record(
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(found=False),
+    )
+    state.record(
+        client_name="NVIDIAEmbeddings",
+        model_name="nvidia/nv-embedqa-e5-v5",
+        success=True,
+        usage=_TokenUsage(found=False),
+    )
+
+    assert state.flush(include_current=True) == 1
+    assert len(captured[0]["events"]) == 1
+
+
+def test_disabled_and_self_hosted_records_do_not_create_global_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from langchain_nvidia_ai_endpoints import _telemetry
+
+    record_usage(
+        enabled=False,
+        is_hosted=True,
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(found=False),
+    )
+    record_usage(
+        enabled=True,
+        is_hosted=False,
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(found=False),
+    )
+    monkeypatch.setenv(
+        "NVIDIA_USAGE_TELEMETRY_ENDPOINT", "https://unapproved.example.test/events"
+    )
+    record_usage(
+        enabled=True,
+        is_hosted=True,
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(found=False),
+    )
+    assert _telemetry._STATE is None
+    assert flush_usage_telemetry() == 0
+
+
+def test_sync_request_records_success_and_failure_without_content() -> None:
+    client = _sync_client()
+    success_response = _response(
+        payload={
+            "choices": [{"message": {"content": "private response"}}],
+            "usage": {"prompt_tokens": 9, "completion_tokens": 4},
+        }
+    )
+    with (
+        patch.object(client, "_post", return_value=(success_response, Mock())),
+        patch.object(client, "_wait", return_value=success_response),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+    ):
+        assert (
+            client.get_req({"messages": [{"content": "private prompt"}]})
+            is success_response
+        )
+    assert record.call_count == 1
+    kwargs = record.call_args.kwargs
+    assert kwargs["success"] is True
+    assert kwargs["usage"] == _TokenUsage(9, 4, True)
+    assert "private" not in repr(kwargs)
+
+    failure_response = _response(status=429)
+    client.last_response = failure_response
+    with (
+        patch.object(client, "_post", side_effect=RuntimeError("private exception")),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+        pytest.raises(RuntimeError, match="private exception"),
+    ):
+        client.get_req({"messages": [{"content": "private prompt"}]})
+    kwargs = record.call_args.kwargs
+    assert kwargs["success"] is False
+    assert kwargs["error_category"] == "rate_limited"
+    assert "private" not in repr(kwargs)
+
+
+def test_telemetry_failures_do_not_change_user_request_result() -> None:
+    client = _sync_client()
+    response = _response(payload={"usage": {"prompt_tokens": 1}})
+    with (
+        patch.object(client, "_post", return_value=(response, Mock())),
+        patch.object(client, "_wait", return_value=response),
+        patch(
+            "langchain_nvidia_ai_endpoints._common.record_usage",
+            side_effect=RuntimeError("telemetry failed"),
+        ),
+    ):
+        assert client.get_req({"messages": []}) is response
+
+    with (
+        patch.object(client, "_post", side_effect=ValueError("request failed")),
+        patch(
+            "langchain_nvidia_ai_endpoints._common.record_usage",
+            side_effect=RuntimeError("telemetry failed"),
+        ),
+        pytest.raises(ValueError, match="request failed"),
+    ):
+        client.get_req({"messages": []})
+
+
+def test_sync_stream_records_usage_and_cancellation() -> None:
+    client = _sync_client()
+    response = SimpleNamespace(
+        status_code=200,
+        raise_for_status=lambda: None,
+        iter_lines=lambda: iter([b"data: chunk", b"data: [DONE]"]),
+    )
+    session = Mock()
+    session.post.return_value = response
+    client.get_session_fn = lambda: session
+    with (
+        patch.object(
+            _NVIDIASyncClient,
+            "postprocess",
+            return_value=(
+                {"usage": {"prompt_tokens": 5, "completion_tokens": 3}},
+                False,
+            ),
+        ),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+    ):
+        assert list(client.get_req_stream({"messages": []}))
+    assert record.call_args.kwargs["success"] is True
+    assert record.call_args.kwargs["usage"] == _TokenUsage(5, 3, True)
+
+    response = SimpleNamespace(
+        status_code=200,
+        raise_for_status=lambda: None,
+        iter_lines=lambda: iter([b"data: first", b"data: second"]),
+    )
+    session.post.return_value = response
+    with (
+        patch.object(_NVIDIASyncClient, "postprocess", return_value=({}, False)),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+    ):
+        stream = cast(
+            Generator[dict, Any, Any],
+            client.get_req_stream({"messages": []}),
+        )
+        next(stream)
+        stream.close()
+    assert record.call_args.kwargs["success"] is False
+    assert record.call_args.kwargs["error_category"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_async_request_records_success() -> None:
+    client = _async_client()
+    response = SimpleNamespace(
+        status=200,
+        text=AsyncMock(
+            return_value=json.dumps(
+                {"usage": {"prompt_tokens": 6, "completion_tokens": 2}}
+            )
+        ),
+    )
+    session = SimpleNamespace(close=AsyncMock())
+    with (
+        patch.object(
+            client, "_post_async", AsyncMock(return_value=(response, session))
+        ),
+        patch.object(client, "_wait_async", AsyncMock(return_value=response)),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+    ):
+        await client.aget_req({"messages": []})
+    assert record.call_args.kwargs["success"] is True
+    assert record.call_args.kwargs["usage"] == _TokenUsage(6, 2, True)
+    session.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_stream_records_usage_and_cancellation() -> None:
+    class Reader:
+        def __init__(self, lines: list[bytes]) -> None:
+            self.lines = iter(lines)
+
+        async def readline(self) -> bytes:
+            return next(self.lines, b"")
+
+    client = _async_client()
+    response = SimpleNamespace(
+        status=200,
+        content=Reader([b"data: chunk", b"data: [DONE]"]),
+    )
+    session = SimpleNamespace(post=AsyncMock(return_value=response), close=AsyncMock())
+    client.get_async_session_fn = lambda: session
+    with (
+        patch.object(
+            _NVIDIAAsyncClient,
+            "postprocess",
+            return_value=(
+                {"usage": {"prompt_tokens": 8, "completion_tokens": 3}},
+                False,
+            ),
+        ),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+    ):
+        assert [item async for item in client.aget_req_stream({"messages": []})]
+    assert record.call_args.kwargs["success"] is True
+    assert record.call_args.kwargs["usage"] == _TokenUsage(8, 3, True)
+
+    response = SimpleNamespace(
+        status=200,
+        content=Reader([b"data: first", b"data: second"]),
+    )
+    session.post = AsyncMock(return_value=response)
+    with (
+        patch.object(_NVIDIAAsyncClient, "postprocess", return_value=({}, False)),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+    ):
+        stream = cast(
+            AsyncGenerator[dict, None],
+            client.aget_req_stream({"messages": []}),
+        )
+        await anext(stream)
+        await stream.aclose()
+    assert record.call_args.kwargs["success"] is False
+    assert record.call_args.kwargs["error_category"] == "cancelled"
+
+
+def test_transport_failures_never_escape() -> None:
+    with patch(
+        "langchain_nvidia_ai_endpoints._telemetry.requests.post",
+        side_effect=requests.ConnectionError("private network detail"),
+    ):
+        _post_envelope(
+            "https://events.example.test/v1.1/events/json",
+            {"events": []},
+        )
+
+
+@pytest.mark.parametrize(
+    ("client", "expected"),
+    [
+        (
+            ChatNVIDIA(
+                model="nvidia/nemotron-3.5-lightning-30b-a3b",
+                api_key="test",
+                usage_telemetry_enabled=True,
+            ),
+            True,
+        ),
+        (
+            NVIDIAEmbeddings(api_key="test", usage_telemetry_enabled=True),
+            True,
+        ),
+        (
+            NVIDIA(api_key="test", usage_telemetry_enabled=True),
+            True,
+        ),
+        (
+            NVIDIARerank(api_key="test", usage_telemetry_enabled=True),
+            True,
+        ),
+        (
+            ChatNVIDIA(
+                model="nvidia/nemotron-3.5-lightning-30b-a3b",
+                api_key="test",
+                usage_telemetry_enabled=False,
+            ),
+            False,
+        ),
+    ],
+)
+def test_public_clients_propagate_explicit_opt_in(client: Any, expected: bool) -> None:
+    assert client._client.usage_telemetry_enabled is expected
+    assert client._async_client.usage_telemetry_enabled is expected


### PR DESCRIPTION
## Summary

Adds explicitly enabled, default-off `nim_client_usage` telemetry to `langchain-nvidia-ai-endpoints`.

- aggregates usage in memory by UTC hour
- covers sync/async and streaming/non-streaming chat, completion, embedding, and rerank calls
- emits only for NVIDIA-hosted NIM endpoints
- maps model inputs through the package's versioned static model allowlist; unknown values remain `unknown`
- records only coarse operation/outcome buckets, counts, and provider-reported aggregate token totals
- never stores telemetry on disk
- isolates telemetry transport failures from user inference requests
- exposes constructor and environment opt-in controls with the disclosure adjacent to the setting

## Privacy and safety

Telemetry is disabled unless explicitly enabled. Event parameters exclude prompts, responses, embeddings, tool inputs/outputs, arbitrary model strings, endpoint URLs, hostnames, IP addresses, credentials, exception text, and persistent user/device/installation/session identifiers.

The transport endpoint is restricted to the approved NVIDIA production and UAT collectors. Self-hosted NIM endpoints never emit this telemetry.

## Verification

- 1,376 unit tests passed; 91 skipped
- 19 telemetry contract/regression tests passed
- Ruff passed
- mypy passed for all 16 package source files
- package wheel and source distribution built successfully
- real `ChatNVIDIA.invoke()` UAT smoke passed: inference succeeded, telemetry POST returned HTTP 200, and exactly one matching `nim_client_usage` event was verified in the NIM UAT index

The PR remains draft while the production governance follow-up is completed.