### PR TITLE
feat(ai-endpoints): expand NIM usage telemetry MVP fields

### DIFF
--- a/libs/ai-endpoints/README.md
+++ b/libs/ai-endpoints/README.md
@@ -52,6 +52,37 @@ To get access to the NVIDIA API Catalog, do the following:
 You can now use your key to access endpoints on the NVIDIA API Catalog.
 
 
+### Optional NVIDIA NIM usage telemetry
+
+Usage telemetry is disabled by default. To opt in for a client instance, set
+`usage_telemetry_enabled=True`:
+
+```python
+llm = ChatNVIDIA(
+    model="nvidia/nemotron-3-super-120b-a12b",
+    usage_telemetry_enabled=True,
+)
+```
+
+Alternatively, set `NVIDIA_USAGE_TELEMETRY_ENABLED=true` to provide the default
+for supported clients in the current process. An explicit constructor value
+overrides the environment setting.
+
+If explicitly enabled, the connector sends hourly aggregated, content-free usage
+metrics to NVIDIA. The aggregate includes connector and LangChain version
+buckets, a coarse operation and outcome category, an allowlisted public NIM ID
+or `unknown`, request and attempt counts, and aggregate token counts when the
+provider returns them.
+
+It does not send prompts, responses, embeddings, tool inputs or outputs, endpoint
+URLs, hostnames, IP addresses, credentials, exception text, or persistent user,
+device, installation, or session identifiers. Aggregates remain in memory only,
+are never written to disk, and apply only to NVIDIA-hosted NIM endpoints.
+Self-hosted endpoints do not emit this telemetry.
+
+For authorized UAT only, set `NVIDIA_USAGE_TELEMETRY_ENDPOINT` to the approved
+test ingestion URL. Do not redirect telemetry to an unapproved collector.
+
 ## Invoke the Core Chat Interface
 
 Use the following code to invoke the core chat interface.

--- a/libs/ai-endpoints/README.md
+++ b/libs/ai-endpoints/README.md
@@ -69,10 +69,12 @@ for supported clients in the current process. An explicit constructor value
 overrides the environment setting.
 
 If explicitly enabled, the connector sends hourly aggregated, content-free usage
-metrics to NVIDIA. The aggregate includes connector and LangChain version
-buckets, a coarse operation and outcome category, an allowlisted public NIM ID
-or `unknown`, request and attempt counts, and aggregate token counts when the
-provider returns them.
+metrics to NVIDIA on a best-effort basis. These totals are not billing-grade.
+The aggregate includes connector and LangChain version buckets, coarse operation,
+execution mode, outcome and HTTP status-class counts, request/attempt/success/
+failure/cancellation/partial/retry/drop counts, latency and time-to-first-token
+histogram buckets, an allowlisted public NIM ID or `unknown`, and aggregate token
+counts when the provider returns them.
 
 It does not send prompts, responses, embeddings, tool inputs or outputs, endpoint
 URLs, hostnames, IP addresses, credentials, exception text, or persistent user,

--- a/libs/ai-endpoints/README.md
+++ b/libs/ai-endpoints/README.md
@@ -52,67 +52,6 @@ To get access to the NVIDIA API Catalog, do the following:
 You can now use your key to access endpoints on the NVIDIA API Catalog.
 
 
-### Telemetry & privacy
-
-`langchain-nvidia-ai-endpoints` includes an optional function to share
-content-free, aggregate telemetry with NVIDIA for product improvement. Telemetry
-is enabled by default for supported NVIDIA-hosted NIM endpoint usage and can be
-disabled as described below. Data collected by the connector is limited to
-operational usage and reliability metrics, such as connector and LangChain
-version, operation type, approved
-public NVIDIA NIM ID or `unknown`, model family, request and retry counts,
-success and failure counts, token counts, missing-token counts, latency buckets,
-and coarse error categories. These totals are best-effort and are not
-billing-grade.
-
-The connector telemetry payload does not collect prompts, responses, embeddings,
-tool inputs or outputs, credentials, endpoint URLs, hostnames, exception text,
-account IDs, organization IDs, or persistent user, device, installation, or
-session identifiers. This data is used to understand aggregate adoption and
-reliability of supported NVIDIA NIM integrations. It is not used to track
-individual user behavior, for billing, or for precise capacity accounting.
-
-Aggregates remain in memory only, are never written to disk, and apply only to
-NVIDIA-hosted NIM endpoints. Self-hosted endpoints do not emit this telemetry.
-
-NVIDIA telemetry infrastructure may add standard transport or routing metadata
-during ingestion and indexing. Any platform-added metadata used or retained for
-this project must be reviewed and approved before production launch.
-
-You may opt out of telemetry collection at any time. Opting out applies only to
-telemetry collection by the `langchain-nvidia-ai-endpoints` connector itself.
-To disable telemetry for the current shell, set
-`NVIDIA_USAGE_TELEMETRY_ENABLED=false` before running your application:
-
-```bash
-export NVIDIA_USAGE_TELEMETRY_ENABLED=false
-```
-
-You can also disable telemetry for a single client instance:
-
-```python
-llm = ChatNVIDIA(
-    model="nvidia/nemotron-3-super-120b-a12b",
-    usage_telemetry_enabled=False,
-)
-```
-
-If telemetry is disabled, the connector does not send telemetry requests and
-telemetry has no effect on connector operation.
-
-**Use of third-party endpoints, including NVIDIA Build:** `langchain-nvidia-ai-endpoints`
-can be configured to use various inference endpoints, including
-[build.nvidia.com](https://build.nvidia.com/) (NVIDIA Build). If you choose to
-use NVIDIA Build or any other third-party endpoint, that endpoint's own terms of
-service and privacy practices apply independently of this library. Any opt-out
-you exercise within `langchain-nvidia-ai-endpoints` does not extend to data
-collection by your chosen endpoint. NVIDIA Build is intended for evaluation and
-testing purposes only and may not be used in production environments. Do not
-submit confidential information or personal data when using NVIDIA Build.
-
-For authorized UAT only, set `NVIDIA_USAGE_TELEMETRY_ENDPOINT` to the approved
-test ingestion URL. Do not redirect telemetry to an unapproved collector.
-
 ## Invoke the Core Chat Interface
 
 Use the following code to invoke the core chat interface.
@@ -461,3 +400,65 @@ embedder = NVIDIAEmbeddings(base_url="http://localhost:8080/v1")
 # Connect to a reranking NIM running at localhost:2016
 ranker = NVIDIARerank(base_url="http://localhost:2016/v1")
 ```
+
+---
+
+## Telemetry & Privacy
+
+`langchain-nvidia-ai-endpoints` includes an optional function to share
+content-free, aggregate telemetry with NVIDIA for product improvement. Telemetry
+is enabled by default for supported NVIDIA-hosted NIM endpoint usage and can be
+disabled as described below. Data collected by the connector is limited to
+operational usage and reliability metrics, such as connector and LangChain
+version, operation type, approved public NVIDIA NIM ID or `unknown`, model
+family, request and retry counts, success and failure counts, token counts,
+missing-token counts, latency buckets, and coarse error categories. These totals
+are best-effort and are not billing-grade.
+
+The connector telemetry payload does not collect prompts, responses, embeddings,
+tool inputs or outputs, credentials, endpoint URLs, hostnames, exception text,
+account IDs, organization IDs, or persistent user, device, installation, or
+session identifiers. This data is used to understand aggregate adoption and
+reliability of supported NVIDIA NIM integrations. It is not used to track
+individual user behavior, for billing, or for precise capacity accounting.
+
+Aggregates remain in memory only, are never written to disk, and apply only to
+NVIDIA-hosted NIM endpoints. Self-hosted endpoints do not emit this telemetry.
+
+NVIDIA telemetry infrastructure may add standard transport or routing metadata
+during ingestion and indexing. Any platform-added metadata used or retained for
+this project must be reviewed and approved before production launch.
+
+You may opt out of telemetry collection at any time. Opting out applies only to
+telemetry collection by the `langchain-nvidia-ai-endpoints` connector itself.
+To disable telemetry for the current shell, set
+`NVIDIA_USAGE_TELEMETRY_ENABLED=false` before running your application:
+
+```bash
+export NVIDIA_USAGE_TELEMETRY_ENABLED=false
+```
+
+You can also disable telemetry for a single client instance:
+
+```python
+llm = ChatNVIDIA(
+    model="nvidia/nemotron-3-super-120b-a12b",
+    usage_telemetry_enabled=False,
+)
+```
+
+If telemetry is disabled, the connector does not send telemetry requests and
+telemetry has no effect on connector operation.
+
+**Use of third-party endpoints, including NVIDIA Build:** `langchain-nvidia-ai-endpoints`
+can be configured to use various inference endpoints, including
+[build.nvidia.com](https://build.nvidia.com/) (NVIDIA Build). If you choose to
+use NVIDIA Build or any other third-party endpoint, that endpoint's own terms of
+service and privacy practices apply independently of this library. Any opt-out
+you exercise within `langchain-nvidia-ai-endpoints` does not extend to data
+collection by your chosen endpoint. NVIDIA Build is intended for evaluation and
+testing purposes only and may not be used in production environments. Do not
+submit confidential information or personal data when using NVIDIA Build.
+
+For authorized UAT only, set `NVIDIA_USAGE_TELEMETRY_ENDPOINT` to the approved
+test ingestion URL. Do not redirect telemetry to an unapproved collector.

--- a/libs/ai-endpoints/README.md
+++ b/libs/ai-endpoints/README.md
@@ -55,36 +55,22 @@ You can now use your key to access endpoints on the NVIDIA API Catalog.
 ### Telemetry & privacy
 
 `langchain-nvidia-ai-endpoints` includes an optional function to share
-content-free, aggregate telemetry with NVIDIA for product improvement. Usage
-telemetry is disabled by default. To opt in for a client instance, set
-`usage_telemetry_enabled=True`:
+content-free, aggregate telemetry with NVIDIA for product improvement. Telemetry
+is enabled by default for supported NVIDIA-hosted NIM endpoint usage and can be
+disabled as described below. Data collected by the connector is limited to
+operational usage and reliability metrics, such as connector and LangChain
+version, operation type, approved
+public NVIDIA NIM ID or `unknown`, model family, request and retry counts,
+success and failure counts, token counts, missing-token counts, latency buckets,
+and coarse error categories. These totals are best-effort and are not
+billing-grade.
 
-```python
-llm = ChatNVIDIA(
-    model="nvidia/nemotron-3-super-120b-a12b",
-    usage_telemetry_enabled=True,
-)
-```
-
-Alternatively, set `NVIDIA_USAGE_TELEMETRY_ENABLED=true` to provide the default
-for supported clients in the current process. An explicit constructor value
-overrides the environment setting.
-
-If explicitly enabled, the connector sends hourly aggregate usage and reliability
-metrics to NVIDIA on a best-effort basis. Data collected by the connector is
-limited to operational metrics such as connector and LangChain version,
-operation type, execution mode, outcome and HTTP status-class counts,
-request/attempt/success/failure/cancellation/partial/retry/drop counts, latency
-and time-to-first-token histogram buckets, an approved public NVIDIA NIM ID or
-`unknown`, model family, aggregate token counts, and missing-token counts when
-the provider returns usage information. These totals are not billing-grade.
-
-The connector telemetry payload does not collect or send prompts, responses,
-embeddings, tool inputs or outputs, credentials, endpoint URLs, hostnames,
-exception text, account IDs, organization IDs, or persistent user, device,
-installation, or session identifiers. This data is used to understand aggregate
-adoption and reliability of supported NVIDIA NIM integrations. It is not used to
-track individual user behavior, for billing, or for precise capacity accounting.
+The connector telemetry payload does not collect prompts, responses, embeddings,
+tool inputs or outputs, credentials, endpoint URLs, hostnames, exception text,
+account IDs, organization IDs, or persistent user, device, installation, or
+session identifiers. This data is used to understand aggregate adoption and
+reliability of supported NVIDIA NIM integrations. It is not used to track
+individual user behavior, for billing, or for precise capacity accounting.
 
 Aggregates remain in memory only, are never written to disk, and apply only to
 NVIDIA-hosted NIM endpoints. Self-hosted endpoints do not emit this telemetry.
@@ -93,9 +79,10 @@ NVIDIA telemetry infrastructure may add standard transport or routing metadata
 during ingestion and indexing. Any platform-added metadata used or retained for
 this project must be reviewed and approved before production launch.
 
-You may disable telemetry at any time. To disable telemetry for the current
-shell, unset `NVIDIA_USAGE_TELEMETRY_ENABLED` or set it to `false` before running
-your application:
+You may opt out of telemetry collection at any time. Opting out applies only to
+telemetry collection by the `langchain-nvidia-ai-endpoints` connector itself.
+To disable telemetry for the current shell, set
+`NVIDIA_USAGE_TELEMETRY_ENABLED=false` before running your application:
 
 ```bash
 export NVIDIA_USAGE_TELEMETRY_ENABLED=false
@@ -111,10 +98,17 @@ llm = ChatNVIDIA(
 ```
 
 If telemetry is disabled, the connector does not send telemetry requests and
-telemetry has no effect on connector operation. Opting out applies only to
-telemetry collection by the `langchain-nvidia-ai-endpoints` connector itself.
-It does not change the terms of service or privacy practices of any inference
-endpoint you choose to use.
+telemetry has no effect on connector operation.
+
+**Use of third-party endpoints, including NVIDIA Build:** `langchain-nvidia-ai-endpoints`
+can be configured to use various inference endpoints, including
+[build.nvidia.com](https://build.nvidia.com/) (NVIDIA Build). If you choose to
+use NVIDIA Build or any other third-party endpoint, that endpoint's own terms of
+service and privacy practices apply independently of this library. Any opt-out
+you exercise within `langchain-nvidia-ai-endpoints` does not extend to data
+collection by your chosen endpoint. NVIDIA Build is intended for evaluation and
+testing purposes only and may not be used in production environments. Do not
+submit confidential information or personal data when using NVIDIA Build.
 
 For authorized UAT only, set `NVIDIA_USAGE_TELEMETRY_ENDPOINT` to the approved
 test ingestion URL. Do not redirect telemetry to an unapproved collector.

--- a/libs/ai-endpoints/README.md
+++ b/libs/ai-endpoints/README.md
@@ -52,9 +52,11 @@ To get access to the NVIDIA API Catalog, do the following:
 You can now use your key to access endpoints on the NVIDIA API Catalog.
 
 
-### Optional NVIDIA NIM usage telemetry
+### Telemetry & privacy
 
-Usage telemetry is disabled by default. To opt in for a client instance, set
+`langchain-nvidia-ai-endpoints` includes an optional function to share
+content-free, aggregate telemetry with NVIDIA for product improvement. Usage
+telemetry is disabled by default. To opt in for a client instance, set
 `usage_telemetry_enabled=True`:
 
 ```python
@@ -68,19 +70,51 @@ Alternatively, set `NVIDIA_USAGE_TELEMETRY_ENABLED=true` to provide the default
 for supported clients in the current process. An explicit constructor value
 overrides the environment setting.
 
-If explicitly enabled, the connector sends hourly aggregated, content-free usage
-metrics to NVIDIA on a best-effort basis. These totals are not billing-grade.
-The aggregate includes connector and LangChain version buckets, coarse operation,
-execution mode, outcome and HTTP status-class counts, request/attempt/success/
-failure/cancellation/partial/retry/drop counts, latency and time-to-first-token
-histogram buckets, an allowlisted public NIM ID or `unknown`, and aggregate token
-counts when the provider returns them.
+If explicitly enabled, the connector sends hourly aggregate usage and reliability
+metrics to NVIDIA on a best-effort basis. Data collected by the connector is
+limited to operational metrics such as connector and LangChain version,
+operation type, execution mode, outcome and HTTP status-class counts,
+request/attempt/success/failure/cancellation/partial/retry/drop counts, latency
+and time-to-first-token histogram buckets, an approved public NVIDIA NIM ID or
+`unknown`, model family, aggregate token counts, and missing-token counts when
+the provider returns usage information. These totals are not billing-grade.
 
-It does not send prompts, responses, embeddings, tool inputs or outputs, endpoint
-URLs, hostnames, IP addresses, credentials, exception text, or persistent user,
-device, installation, or session identifiers. Aggregates remain in memory only,
-are never written to disk, and apply only to NVIDIA-hosted NIM endpoints.
-Self-hosted endpoints do not emit this telemetry.
+The connector telemetry payload does not collect or send prompts, responses,
+embeddings, tool inputs or outputs, credentials, endpoint URLs, hostnames,
+exception text, account IDs, organization IDs, or persistent user, device,
+installation, or session identifiers. This data is used to understand aggregate
+adoption and reliability of supported NVIDIA NIM integrations. It is not used to
+track individual user behavior, for billing, or for precise capacity accounting.
+
+Aggregates remain in memory only, are never written to disk, and apply only to
+NVIDIA-hosted NIM endpoints. Self-hosted endpoints do not emit this telemetry.
+
+NVIDIA telemetry infrastructure may add standard transport or routing metadata
+during ingestion and indexing. Any platform-added metadata used or retained for
+this project must be reviewed and approved before production launch.
+
+You may disable telemetry at any time. To disable telemetry for the current
+shell, unset `NVIDIA_USAGE_TELEMETRY_ENABLED` or set it to `false` before running
+your application:
+
+```bash
+export NVIDIA_USAGE_TELEMETRY_ENABLED=false
+```
+
+You can also disable telemetry for a single client instance:
+
+```python
+llm = ChatNVIDIA(
+    model="nvidia/nemotron-3-super-120b-a12b",
+    usage_telemetry_enabled=False,
+)
+```
+
+If telemetry is disabled, the connector does not send telemetry requests and
+telemetry has no effect on connector operation. Opting out applies only to
+telemetry collection by the `langchain-nvidia-ai-endpoints` connector itself.
+It does not change the terms of service or privacy practices of any inference
+endpoint you choose to use.
 
 For authorized UAT only, set `NVIDIA_USAGE_TELEMETRY_ENDPOINT` to the approved
 test ingestion URL. Do not redirect telemetry to an unapproved collector.

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -35,6 +35,16 @@ from pydantic import (
 from requests.models import Response
 
 from langchain_nvidia_ai_endpoints._statics import MODEL_TABLE, Model, determine_model
+from langchain_nvidia_ai_endpoints._telemetry import (
+    _TokenUsage,
+    classify_error,
+    merge_token_usage,
+    record_usage,
+    token_usage,
+)
+from langchain_nvidia_ai_endpoints._telemetry import (
+    usage_telemetry_enabled as _usage_telemetry_enabled,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +108,16 @@ class _NVIDIABaseClient(BaseModel):
         if _API_KEY_VAR in os.environ
         else None,
         description="API Key for service of choice",
+    )
+
+    usage_telemetry_enabled: bool = Field(
+        default_factory=_usage_telemetry_enabled,
+        exclude=True,
+        repr=False,
+        description=(
+            "Enable content-free aggregate usage telemetry for NVIDIA-hosted NIMs. "
+            "Disabled by default."
+        ),
     )
 
     ## Generation arguments
@@ -329,6 +349,34 @@ class _NVIDIABaseClient(BaseModel):
                 "Authorization": f"Bearer {self.api_key.get_secret_value()}",
             }
         return payload
+
+    def _record_usage_success(self, value: Any) -> None:
+        try:
+            usage = value if isinstance(value, _TokenUsage) else token_usage(value)
+            record_usage(
+                enabled=self.usage_telemetry_enabled,
+                is_hosted=self.is_hosted,
+                client_name=self.cls,
+                model_name=self.mdl_name,
+                success=True,
+                usage=usage,
+            )
+        except Exception:
+            pass
+
+    def _record_usage_failure(self, error: BaseException) -> None:
+        try:
+            record_usage(
+                enabled=self.usage_telemetry_enabled,
+                is_hosted=self.is_hosted,
+                client_name=self.cls,
+                model_name=self.mdl_name,
+                success=False,
+                usage=_TokenUsage(),
+                error_category=classify_error(self.last_response, error),
+            )
+        except Exception:
+            pass
 
     ###################################################################################
     ################### Model discovery and selection #################################
@@ -609,10 +657,16 @@ class _NVIDIASyncClient(_NVIDIABaseClient):
         extra_headers: dict = {},
     ) -> Response:
         """Post to the API."""
-        response, session = self._post(
-            self.infer_url, payload, extra_headers=extra_headers
-        )
-        return self._wait(response, session)
+        try:
+            response, session = self._post(
+                self.infer_url, payload, extra_headers=extra_headers
+            )
+            response = self._wait(response, session)
+            self._record_usage_success(response)
+            return response
+        except BaseException as error:
+            self._record_usage_failure(error)
+            raise
 
     ###################################################################################
     ## Streaming interface to allow you to iterate through progressive generations ####
@@ -631,22 +685,36 @@ class _NVIDIASyncClient(_NVIDIABaseClient):
             "json": payload,
         }
 
-        response = self.get_session_fn().post(
-            stream=True,
-            **self._add_authorization(self.last_inputs),
-            timeout=self.timeout,
-        )
-        self._try_raise(response)
+        try:
+            self.last_response = response = self.get_session_fn().post(
+                stream=True,
+                **self._add_authorization(self.last_inputs),
+                timeout=self.timeout,
+            )
+            self._try_raise(response)
+        except BaseException as error:
+            self._record_usage_failure(error)
+            raise
         call: _NVIDIASyncClient = self.model_copy()
 
         def out_gen() -> Generator[dict, Any, Any]:
-            ## Good for client, since it allows self.last_inputs
-            for line in response.iter_lines():
-                if line and line.strip() != b"data: [DONE]":
-                    line = line.decode("utf-8")
-                    msg, final_line = call.postprocess(line)
-                    yield msg
-                self._try_raise(response)
+            usage = _TokenUsage()
+            completed = False
+            try:
+                for line in response.iter_lines():
+                    if line and line.strip() != b"data: [DONE]":
+                        line = line.decode("utf-8")
+                        msg, final_line = call.postprocess(line)
+                        usage = merge_token_usage(usage, token_usage(msg))
+                        yield msg
+                    self._try_raise(response)
+                completed = True
+            except BaseException as error:
+                self._record_usage_failure(error)
+                raise
+            finally:
+                if completed:
+                    self._record_usage_success(usage)
 
         return (r for r in out_gen())
 
@@ -816,15 +884,20 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
         extra_headers: dict = {},
     ) -> str:
         """Async version of `get_req`."""
-        response, session = await self._post_async(
-            self.infer_url, payload, extra_headers=extra_headers
-        )
         try:
-            response = await self._wait_async(response, session)
-            text = await response.text()
-            return text
-        finally:
-            await session.close()
+            response, session = await self._post_async(
+                self.infer_url, payload, extra_headers=extra_headers
+            )
+            try:
+                response = await self._wait_async(response, session)
+                text = await response.text()
+                self._record_usage_success(text)
+                return text
+            finally:
+                await session.close()
+        except BaseException as error:
+            self._record_usage_failure(error)
+            raise
 
     async def aget_req_stream(
         self,
@@ -842,6 +915,8 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
         }
 
         session = self.get_async_session_fn()
+        usage = _TokenUsage()
+        completed = False
         try:
             self.last_response = response = await session.post(
                 **self._add_authorization(self.last_inputs)
@@ -858,10 +933,17 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
                 if line and line != b"data: [DONE]":
                     line_str = line.decode("utf-8")
                     msg, final_line = call.postprocess(line_str)
+                    usage = merge_token_usage(usage, token_usage(msg))
                     yield msg
                 await self._try_raise_async(response)
+            completed = True
+        except BaseException as error:
+            self._record_usage_failure(error)
+            raise
         finally:
             await session.close()
+            if completed:
+                self._record_usage_success(usage)
 
 
 def _build_clients(

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -530,9 +530,9 @@ class _NVIDIABaseClient(BaseModel):
                     f"Timeout reached without a successful response."
                     f"\nLast response: {str(response)}"
                 )
-            assert "NVCF-REQID" in response.headers, (
-                "Received 202 response with no request id to follow"
-            )
+            assert (
+                "NVCF-REQID" in response.headers
+            ), "Received 202 response with no request id to follow"
             request_id = response.headers.get("NVCF-REQID")
             payload = {
                 "url": self.polling_url_tmpl.format(request_id=request_id),
@@ -873,9 +873,9 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
                     f"Timeout reached without a successful response."
                     f"\nLast response: {str(response)}"
                 )
-            assert "NVCF-REQID" in response.headers, (
-                "Received 202 response with no request id to follow"
-            )
+            assert (
+                "NVCF-REQID" in response.headers
+            ), "Received 202 response with no request id to follow"
             request_id = response.headers.get("NVCF-REQID")
             payload = {
                 "url": self.polling_url_tmpl.format(request_id=request_id),

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -38,6 +38,7 @@ from langchain_nvidia_ai_endpoints._statics import MODEL_TABLE, Model, determine
 from langchain_nvidia_ai_endpoints._telemetry import (
     _TokenUsage,
     classify_error,
+    http_status_class,
     merge_token_usage,
     record_usage,
     token_usage,
@@ -102,11 +103,11 @@ class _NVIDIABaseClient(BaseModel):
     )
 
     api_key: Optional[SecretStr] = Field(
-        default_factory=lambda: SecretStr(
-            os.getenv(_API_KEY_VAR, "INTERNAL_LCNVAIE_ERROR")
-        )
-        if _API_KEY_VAR in os.environ
-        else None,
+        default_factory=lambda: (
+            SecretStr(os.getenv(_API_KEY_VAR, "INTERNAL_LCNVAIE_ERROR"))
+            if _API_KEY_VAR in os.environ
+            else None
+        ),
         description="API Key for service of choice",
     )
 
@@ -350,7 +351,14 @@ class _NVIDIABaseClient(BaseModel):
             }
         return payload
 
-    def _record_usage_success(self, value: Any) -> None:
+    def _record_usage_success(
+        self,
+        value: Any,
+        *,
+        execution_mode: str,
+        latency_seconds: float,
+        ttft_seconds: Optional[float] = None,
+    ) -> None:
         try:
             usage = value if isinstance(value, _TokenUsage) else token_usage(value)
             record_usage(
@@ -360,11 +368,23 @@ class _NVIDIABaseClient(BaseModel):
                 model_name=self.mdl_name,
                 success=True,
                 usage=usage,
+                execution_mode=execution_mode,
+                http_status=http_status_class(self.last_response),
+                latency_seconds=latency_seconds,
+                ttft_seconds=ttft_seconds,
             )
         except Exception:
             pass
 
-    def _record_usage_failure(self, error: BaseException) -> None:
+    def _record_usage_failure(
+        self,
+        error: BaseException,
+        *,
+        execution_mode: str,
+        latency_seconds: float,
+        ttft_seconds: Optional[float] = None,
+        partial: bool = False,
+    ) -> None:
         try:
             record_usage(
                 enabled=self.usage_telemetry_enabled,
@@ -374,6 +394,11 @@ class _NVIDIABaseClient(BaseModel):
                 success=False,
                 usage=_TokenUsage(),
                 error_category=classify_error(self.last_response, error),
+                execution_mode=execution_mode,
+                http_status=http_status_class(self.last_response),
+                latency_seconds=latency_seconds,
+                ttft_seconds=ttft_seconds,
+                partial=partial,
             )
         except Exception:
             pass
@@ -505,9 +530,9 @@ class _NVIDIABaseClient(BaseModel):
                     f"Timeout reached without a successful response."
                     f"\nLast response: {str(response)}"
                 )
-            assert (
-                "NVCF-REQID" in response.headers
-            ), "Received 202 response with no request id to follow"
+            assert "NVCF-REQID" in response.headers, (
+                "Received 202 response with no request id to follow"
+            )
             request_id = response.headers.get("NVCF-REQID")
             payload = {
                 "url": self.polling_url_tmpl.format(request_id=request_id),
@@ -657,15 +682,26 @@ class _NVIDIASyncClient(_NVIDIABaseClient):
         extra_headers: dict = {},
     ) -> Response:
         """Post to the API."""
+        start_time = time.monotonic()
         try:
             response, session = self._post(
                 self.infer_url, payload, extra_headers=extra_headers
             )
+            self.last_response = response
             response = self._wait(response, session)
-            self._record_usage_success(response)
+            self.last_response = response
+            self._record_usage_success(
+                response,
+                execution_mode="sync",
+                latency_seconds=time.monotonic() - start_time,
+            )
             return response
         except BaseException as error:
-            self._record_usage_failure(error)
+            self._record_usage_failure(
+                error,
+                execution_mode="sync",
+                latency_seconds=time.monotonic() - start_time,
+            )
             raise
 
     ###################################################################################
@@ -676,6 +712,7 @@ class _NVIDIASyncClient(_NVIDIABaseClient):
         payload: dict,
         extra_headers: dict = {},
     ) -> Iterator[Dict]:
+        start_time = time.monotonic()
         self.last_inputs = {
             "url": self.infer_url,
             "headers": {
@@ -693,16 +730,23 @@ class _NVIDIASyncClient(_NVIDIABaseClient):
             )
             self._try_raise(response)
         except BaseException as error:
-            self._record_usage_failure(error)
+            self._record_usage_failure(
+                error,
+                execution_mode="streaming",
+                latency_seconds=time.monotonic() - start_time,
+            )
             raise
         call: _NVIDIASyncClient = self.model_copy()
 
         def out_gen() -> Generator[dict, Any, Any]:
             usage = _TokenUsage()
             completed = False
+            ttft_seconds: Optional[float] = None
             try:
                 for line in response.iter_lines():
                     if line and line.strip() != b"data: [DONE]":
+                        if ttft_seconds is None:
+                            ttft_seconds = time.monotonic() - start_time
                         line = line.decode("utf-8")
                         msg, final_line = call.postprocess(line)
                         usage = merge_token_usage(usage, token_usage(msg))
@@ -710,11 +754,22 @@ class _NVIDIASyncClient(_NVIDIABaseClient):
                     self._try_raise(response)
                 completed = True
             except BaseException as error:
-                self._record_usage_failure(error)
+                self._record_usage_failure(
+                    error,
+                    execution_mode="streaming",
+                    latency_seconds=time.monotonic() - start_time,
+                    ttft_seconds=ttft_seconds,
+                    partial=ttft_seconds is not None,
+                )
                 raise
             finally:
                 if completed:
-                    self._record_usage_success(usage)
+                    self._record_usage_success(
+                        usage,
+                        execution_mode="streaming",
+                        latency_seconds=time.monotonic() - start_time,
+                        ttft_seconds=ttft_seconds,
+                    )
 
         return (r for r in out_gen())
 
@@ -818,9 +873,9 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
                     f"Timeout reached without a successful response."
                     f"\nLast response: {str(response)}"
                 )
-            assert (
-                "NVCF-REQID" in response.headers
-            ), "Received 202 response with no request id to follow"
+            assert "NVCF-REQID" in response.headers, (
+                "Received 202 response with no request id to follow"
+            )
             request_id = response.headers.get("NVCF-REQID")
             payload = {
                 "url": self.polling_url_tmpl.format(request_id=request_id),
@@ -884,19 +939,30 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
         extra_headers: dict = {},
     ) -> str:
         """Async version of `get_req`."""
+        start_time = time.monotonic()
         try:
             response, session = await self._post_async(
                 self.infer_url, payload, extra_headers=extra_headers
             )
+            self.last_response = response
             try:
                 response = await self._wait_async(response, session)
+                self.last_response = response
                 text = await response.text()
-                self._record_usage_success(text)
+                self._record_usage_success(
+                    text,
+                    execution_mode="async",
+                    latency_seconds=time.monotonic() - start_time,
+                )
                 return text
             finally:
                 await session.close()
         except BaseException as error:
-            self._record_usage_failure(error)
+            self._record_usage_failure(
+                error,
+                execution_mode="async",
+                latency_seconds=time.monotonic() - start_time,
+            )
             raise
 
     async def aget_req_stream(
@@ -905,6 +971,7 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
         extra_headers: dict = {},
     ) -> AsyncIterator[Dict]:
         """Async version of `get_req_stream`."""
+        start_time = time.monotonic()
         self.last_inputs = {
             "url": self.infer_url,
             "headers": {
@@ -917,6 +984,7 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
         session = self.get_async_session_fn()
         usage = _TokenUsage()
         completed = False
+        ttft_seconds: Optional[float] = None
         try:
             self.last_response = response = await session.post(
                 **self._add_authorization(self.last_inputs)
@@ -931,6 +999,8 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
                     break
                 line = line.strip()
                 if line and line != b"data: [DONE]":
+                    if ttft_seconds is None:
+                        ttft_seconds = time.monotonic() - start_time
                     line_str = line.decode("utf-8")
                     msg, final_line = call.postprocess(line_str)
                     usage = merge_token_usage(usage, token_usage(msg))
@@ -938,12 +1008,23 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
                 await self._try_raise_async(response)
             completed = True
         except BaseException as error:
-            self._record_usage_failure(error)
+            self._record_usage_failure(
+                error,
+                execution_mode="streaming",
+                latency_seconds=time.monotonic() - start_time,
+                ttft_seconds=ttft_seconds,
+                partial=ttft_seconds is not None,
+            )
             raise
         finally:
             await session.close()
             if completed:
-                self._record_usage_success(usage)
+                self._record_usage_success(
+                    usage,
+                    execution_mode="streaming",
+                    latency_seconds=time.monotonic() - start_time,
+                    ttft_seconds=ttft_seconds,
+                )
 
 
 def _build_clients(

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_common.py
@@ -117,7 +117,7 @@ class _NVIDIABaseClient(BaseModel):
         repr=False,
         description=(
             "Enable content-free aggregate usage telemetry for NVIDIA-hosted NIMs. "
-            "Disabled by default."
+            "Enabled by default unless disabled."
         ),
     )
 
@@ -530,9 +530,9 @@ class _NVIDIABaseClient(BaseModel):
                     f"Timeout reached without a successful response."
                     f"\nLast response: {str(response)}"
                 )
-            assert (
-                "NVCF-REQID" in response.headers
-            ), "Received 202 response with no request id to follow"
+            assert "NVCF-REQID" in response.headers, (
+                "Received 202 response with no request id to follow"
+            )
             request_id = response.headers.get("NVCF-REQID")
             payload = {
                 "url": self.polling_url_tmpl.format(request_id=request_id),
@@ -873,9 +873,9 @@ class _NVIDIAAsyncClient(_NVIDIABaseClient):
                     f"Timeout reached without a successful response."
                     f"\nLast response: {str(response)}"
                 )
-            assert (
-                "NVCF-REQID" in response.headers
-            ), "Received 202 response with no request id to follow"
+            assert "NVCF-REQID" in response.headers, (
+                "Received 202 response with no request id to follow"
+            )
             request_id = response.headers.get("NVCF-REQID")
             payload = {
                 "url": self.polling_url_tmpl.format(request_id=request_id),

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_telemetry.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_telemetry.py
@@ -8,7 +8,7 @@ import importlib.metadata
 import os
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Mapping, Optional
 from uuid import uuid4
@@ -21,10 +21,11 @@ from langchain_nvidia_ai_endpoints._version import __version__
 
 _CLIENT_ID = "623344073512268"
 _EVENT_SCHEMA_VERSION = "1.0"
-_REGISTRY_SCHEMA_VERSION = "0.1"
+_REGISTRY_SCHEMA_VERSION = "0.2"
 _EVENT_PROTOCOL = "1.6"
 _EVENT_NAME = "nim_client_usage"
 _CONNECTOR = "langchain-nvidia-ai-endpoints"
+_TELEMETRY_CLIENT_VERSION = "1.0"
 _DEFAULT_ENDPOINT = "https://events.telemetry.data.nvidia.com/v1.1/events/json"
 _UAT_ENDPOINT = "https://events.telemetry.data-uat.nvidia.com/v1.1/events/json"
 _ALLOWED_ENDPOINTS = frozenset({_DEFAULT_ENDPOINT, _UAT_ENDPOINT})
@@ -40,6 +41,29 @@ _OPERATION_BY_CLIENT = {
     "NVIDIARerank": "rerank",
     "NVIDIA": "completion",
 }
+_ERROR_CATEGORIES = (
+    "authentication",
+    "authorization",
+    "rate_limited",
+    "timeout",
+    "network",
+    "provider_4xx",
+    "provider_5xx",
+    "client_validation",
+    "cancelled",
+    "unknown",
+)
+_HTTP_STATUS_CLASSES = ("2xx", "4xx", "5xx", "none", "unknown")
+_LATENCY_BUCKETS = (
+    ("le_100_ms", 0.1),
+    ("le_250_ms", 0.25),
+    ("le_500_ms", 0.5),
+    ("le_1000_ms", 1.0),
+    ("le_2500_ms", 2.5),
+    ("le_5000_ms", 5.0),
+    ("le_10000_ms", 10.0),
+)
+_OVERFLOW_BUCKET = "gt_10000_ms"
 
 _APPROVED_MODEL_LOOKUP: dict[str, str] = {}
 for _approved_model in MODEL_TABLE.values():
@@ -52,6 +76,7 @@ for _approved_model in MODEL_TABLE.values():
 class _UsageKey:
     window_start: str
     connector_version: str
+    execution_mode: str
     framework_version: str
     operation: str
     model_family: str
@@ -63,11 +88,30 @@ class _UsageKey:
 class _UsageAggregate:
     success_count: int = 0
     failure_count: int = 0
+    cancelled_count: int = 0
+    partial_count: int = 0
     request_count: int = 0
     attempt_count: int = 0
+    retried_request_count: int = 0
+    first_attempt_success_count: int = 0
     input_token_sum: int = 0
     output_token_sum: int = 0
     missing_token_count: int = 0
+    missing_token_attempt_count: int = 0
+    error_category_counts: dict[str, int] = field(
+        default_factory=lambda: _zero_counts(_ERROR_CATEGORIES)
+    )
+    http_status_class_counts: dict[str, int] = field(
+        default_factory=lambda: _zero_counts(_HTTP_STATUS_CLASSES)
+    )
+    latency_bucket_counts: dict[str, int] = field(
+        default_factory=lambda: _zero_latency_buckets()
+    )
+    ttft_bucket_counts: dict[str, int] = field(
+        default_factory=lambda: _zero_latency_buckets()
+    )
+    missing_ttft_count: int = 0
+    client_drop_count: int = 0
 
     def record(
         self,
@@ -76,13 +120,28 @@ class _UsageAggregate:
         input_tokens: int,
         output_tokens: int,
         tokens_missing: bool,
+        error_category: str,
+        http_status_class: str,
+        execution_mode: str,
+        latency_seconds: float,
+        ttft_seconds: Optional[float],
+        partial: bool,
     ) -> None:
         self.request_count = min(_MAX_COUNT, self.request_count + 1)
         self.attempt_count = min(_MAX_COUNT, self.attempt_count + 1)
         if success:
             self.success_count = min(_MAX_COUNT, self.success_count + 1)
+            self.first_attempt_success_count = min(
+                _MAX_COUNT, self.first_attempt_success_count + 1
+            )
         else:
             self.failure_count = min(_MAX_COUNT, self.failure_count + 1)
+            if error_category == "cancelled":
+                self.cancelled_count = min(_MAX_COUNT, self.cancelled_count + 1)
+            if partial:
+                self.partial_count = min(_MAX_COUNT, self.partial_count + 1)
+            if error_category in self.error_category_counts:
+                _increment_count(self.error_category_counts, error_category)
         self.input_token_sum = min(
             _MAX_TOKEN_SUM, self.input_token_sum + max(0, input_tokens)
         )
@@ -91,6 +150,16 @@ class _UsageAggregate:
         )
         if tokens_missing:
             self.missing_token_count = min(_MAX_COUNT, self.missing_token_count + 1)
+            self.missing_token_attempt_count = min(
+                _MAX_COUNT, self.missing_token_attempt_count + 1
+            )
+        _increment_count(self.http_status_class_counts, http_status_class)
+        _increment_bucket(self.latency_bucket_counts, latency_seconds)
+        if execution_mode == "streaming":
+            if ttft_seconds is None:
+                self.missing_ttft_count = min(_MAX_COUNT, self.missing_ttft_count + 1)
+            else:
+                _increment_bucket(self.ttft_bucket_counts, ttft_seconds)
 
 
 @dataclass(frozen=True)
@@ -98,6 +167,12 @@ class _TokenUsage:
     input_tokens: int = 0
     output_tokens: int = 0
     found: bool = False
+
+
+@dataclass(frozen=True)
+class _TransportDelivery:
+    retry_count: int = 0
+    terminal_failure: bool = False
 
 
 def usage_telemetry_enabled(value: Optional[bool] = None) -> bool:
@@ -240,12 +315,29 @@ def classify_error(response: Any, error: BaseException) -> str:
     return "unknown"
 
 
+def http_status_class(response: Any) -> str:
+    """Map a response status to the approved coarse status-class bucket."""
+
+    status = getattr(response, "status_code", None)
+    if status is None:
+        status = getattr(response, "status", None)
+    if not isinstance(status, int):
+        return "none"
+    if 200 <= status < 300:
+        return "2xx"
+    if 400 <= status < 500:
+        return "4xx"
+    if status >= 500:
+        return "5xx"
+    return "unknown"
+
+
 class _UsageTelemetry:
     def __init__(
         self,
         *,
         endpoint: str,
-        post: Callable[[str, dict[str, Any]], None],
+        post: Callable[[str, dict[str, Any]], Any],
         now: Callable[[], datetime],
         start_worker: bool = True,
         max_buckets: int = _MAX_BUCKETS,
@@ -261,6 +353,9 @@ class _UsageTelemetry:
         self._thread: Optional[threading.Thread] = None
         self._wake = threading.Event()
         self._closed = False
+        self._pending_client_drop_count = 0
+        self._pending_transport_retry_count = 0
+        self._pending_terminal_send_failure_count = 0
 
     def record(
         self,
@@ -270,13 +365,20 @@ class _UsageTelemetry:
         success: bool,
         usage: _TokenUsage,
         error_category: str = "none",
+        execution_mode: str = "sync",
+        http_status: str = "none",
+        latency_seconds: float = 0.0,
+        ttft_seconds: Optional[float] = None,
+        partial: bool = False,
     ) -> None:
         now = self._now().astimezone(timezone.utc)
         canonical_id, family = canonical_model_identity(model_name)
-        category = "none" if success else error_category
+        category = "none" if success else _error_category(error_category)
+        status_class = _http_status_class(http_status)
         key = _UsageKey(
             window_start=_hour_start(now),
             connector_version=_version_bucket(__version__),
+            execution_mode=_execution_mode(execution_mode),
             framework_version=_framework_version_bucket(),
             operation=operation_for_client(client_name),
             model_family=family,
@@ -289,13 +391,28 @@ class _UsageTelemetry:
             aggregate = self._aggregates.get(key)
             if aggregate is None:
                 if len(self._aggregates) >= self._max_buckets:
+                    self._pending_client_drop_count = min(
+                        _MAX_COUNT, self._pending_client_drop_count + 1
+                    )
                     return
                 aggregate = self._aggregates[key] = _UsageAggregate()
+            if self._pending_client_drop_count:
+                aggregate.client_drop_count = min(
+                    _MAX_COUNT,
+                    aggregate.client_drop_count + self._pending_client_drop_count,
+                )
+                self._pending_client_drop_count = 0
             aggregate.record(
                 success=success,
                 input_tokens=usage.input_tokens,
                 output_tokens=usage.output_tokens,
                 tokens_missing=not usage.found,
+                error_category=category,
+                http_status_class=status_class,
+                execution_mode=key.execution_mode,
+                latency_seconds=latency_seconds,
+                ttft_seconds=ttft_seconds,
+                partial=partial,
             )
             if self._start_worker and self._thread is None:
                 self._thread = threading.Thread(
@@ -321,11 +438,45 @@ class _UsageTelemetry:
         if not ready:
             return 0
         batch_id = str(uuid4())
-        events = [
-            _event_payload(key, aggregate, batch_id=batch_id)
-            for key, aggregate in ready
-        ]
-        self._post(self._endpoint, _transport_envelope(events, now=now))
+        pending_retry_count = self._pending_transport_retry_count
+        pending_failure_count = self._pending_terminal_send_failure_count
+        events = []
+        for index, (key, aggregate) in enumerate(ready):
+            events.append(
+                _event_payload(
+                    key,
+                    aggregate,
+                    batch_id=batch_id,
+                    transport_retry_count=pending_retry_count if index == 0 else 0,
+                    prior_terminal_send_failure_count=(
+                        pending_failure_count if index == 0 else 0
+                    ),
+                )
+            )
+        try:
+            delivery = self._post(self._endpoint, _transport_envelope(events, now=now))
+        except Exception:
+            delivery = _TransportDelivery(terminal_failure=True)
+        if isinstance(delivery, _TransportDelivery):
+            with self._lock:
+                if delivery.terminal_failure:
+                    self._pending_transport_retry_count = min(
+                        _MAX_COUNT,
+                        self._pending_transport_retry_count + delivery.retry_count,
+                    )
+                    self._pending_terminal_send_failure_count = min(
+                        _MAX_COUNT,
+                        self._pending_terminal_send_failure_count + 1,
+                    )
+                else:
+                    self._pending_transport_retry_count = min(
+                        _MAX_COUNT, delivery.retry_count
+                    )
+                    self._pending_terminal_send_failure_count = 0
+        else:
+            with self._lock:
+                self._pending_transport_retry_count = 0
+                self._pending_terminal_send_failure_count = 0
         return len(events)
 
     def close(self) -> None:
@@ -361,6 +512,11 @@ def record_usage(
     success: bool,
     usage: _TokenUsage,
     error_category: str = "none",
+    execution_mode: str = "sync",
+    http_status: str = "none",
+    latency_seconds: float = 0.0,
+    ttft_seconds: Optional[float] = None,
+    partial: bool = False,
 ) -> None:
     """Record one logical request without retaining request or response content."""
 
@@ -375,6 +531,11 @@ def record_usage(
         success=success,
         usage=usage,
         error_category=error_category,
+        execution_mode=execution_mode,
+        http_status=http_status,
+        latency_seconds=latency_seconds,
+        ttft_seconds=ttft_seconds,
+        partial=partial,
     )
 
 
@@ -417,8 +578,9 @@ def _reset_usage_telemetry_for_tests() -> None:
         state.close()
 
 
-def _post_envelope(endpoint: str, payload: dict[str, Any]) -> None:
+def _post_envelope(endpoint: str, payload: dict[str, Any]) -> _TransportDelivery:
     timeout = _bounded_float(os.getenv("NVIDIA_USAGE_TELEMETRY_TIMEOUT_SECONDS"), 2.0)
+    retry_count = 0
     for attempt in range(3):
         try:
             response = requests.post(
@@ -433,18 +595,26 @@ def _post_envelope(endpoint: str, payload: dict[str, Any]) -> None:
             )
         except requests.exceptions.RequestException:
             if attempt < 2:
+                retry_count += 1
                 time.sleep(0.1 * (2**attempt))
             continue
         if response.ok:
-            return
+            return _TransportDelivery(retry_count=retry_count)
         if response.status_code not in {408, 429} and response.status_code < 500:
-            return
+            return _TransportDelivery(retry_count=retry_count, terminal_failure=True)
         if attempt < 2:
+            retry_count += 1
             time.sleep(0.1 * (2**attempt))
+    return _TransportDelivery(retry_count=retry_count, terminal_failure=True)
 
 
 def _event_payload(
-    key: _UsageKey, aggregate: _UsageAggregate, *, batch_id: str
+    key: _UsageKey,
+    aggregate: _UsageAggregate,
+    *,
+    batch_id: str,
+    transport_retry_count: int = 0,
+    prior_terminal_send_failure_count: int = 0,
 ) -> dict[str, Any]:
     return {
         "ts": _iso_timestamp(datetime.now(timezone.utc)),
@@ -452,21 +622,36 @@ def _event_payload(
         "parameters": {
             "eventSchemaVersion": _EVENT_SCHEMA_VERSION,
             "windowStart": key.window_start,
+            "telemetryClientVersion": _TELEMETRY_CLIENT_VERSION,
             "connector": _CONNECTOR,
             "connectorVersion": key.connector_version,
             "framework": "langchain",
             "frameworkVersion": key.framework_version,
             "operation": key.operation,
+            "executionMode": key.execution_mode,
             "modelFamily": key.model_family,
             "nimId": key.nim_id,
             "successCount": aggregate.success_count,
             "failureCount": aggregate.failure_count,
+            "cancelledCount": aggregate.cancelled_count,
+            "partialCount": aggregate.partial_count,
             "requestCount": aggregate.request_count,
             "attemptCount": aggregate.attempt_count,
+            "retriedRequestCount": aggregate.retried_request_count,
+            "firstAttemptSuccessCount": aggregate.first_attempt_success_count,
             "inputTokenSum": aggregate.input_token_sum,
             "outputTokenSum": aggregate.output_token_sum,
             "missingTokenCount": aggregate.missing_token_count,
+            "missingTokenAttemptCount": aggregate.missing_token_attempt_count,
             "errorCategory": key.error_category,
+            "errorCategoryCounts": dict(aggregate.error_category_counts),
+            "httpStatusClassCounts": dict(aggregate.http_status_class_counts),
+            "latencyBucketCounts": dict(aggregate.latency_bucket_counts),
+            "ttftBucketCounts": dict(aggregate.ttft_bucket_counts),
+            "missingTtftCount": aggregate.missing_ttft_count,
+            "clientDropCount": aggregate.client_drop_count,
+            "transportRetryCount": transport_retry_count,
+            "priorTerminalSendFailureCount": prior_terminal_send_failure_count,
             "batchId": batch_id,
         },
     }
@@ -523,6 +708,22 @@ def _version_bucket(value: str) -> str:
     return f"{int(parts[0])}.{int(parts[1])}"
 
 
+def _execution_mode(value: str) -> str:
+    return (
+        value
+        if value in {"sync", "async", "streaming", "batch", "other"}
+        else "unknown"
+    )
+
+
+def _error_category(value: str) -> str:
+    return value if value in _ERROR_CATEGORIES else "unknown"
+
+
+def _http_status_class(value: str) -> str:
+    return value if value in _HTTP_STATUS_CLASSES else "unknown"
+
+
 def _hour_start(value: datetime) -> str:
     value = value.astimezone(timezone.utc).replace(minute=0, second=0, microsecond=0)
     return value.strftime("%Y-%m-%dT%H:00:00Z")
@@ -544,6 +745,28 @@ def _nonnegative_int(value: Any) -> int:
         return max(0, int(value))
     except (TypeError, ValueError):
         return 0
+
+
+def _zero_counts(keys: tuple[str, ...]) -> dict[str, int]:
+    return {key: 0 for key in keys}
+
+
+def _zero_latency_buckets() -> dict[str, int]:
+    return {key: 0 for key, _ in _LATENCY_BUCKETS} | {_OVERFLOW_BUCKET: 0}
+
+
+def _increment_count(values: dict[str, int], key: str) -> None:
+    values[key] = min(_MAX_COUNT, values.get(key, 0) + 1)
+
+
+def _increment_bucket(values: dict[str, int], duration_seconds: float) -> None:
+    bucket = _OVERFLOW_BUCKET
+    duration_seconds = max(0.0, duration_seconds)
+    for candidate, upper_bound in _LATENCY_BUCKETS:
+        if duration_seconds <= upper_bound:
+            bucket = candidate
+            break
+    _increment_count(values, bucket)
 
 
 def _bounded_float(value: Optional[str], default: float) -> float:

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_telemetry.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_telemetry.py
@@ -1,0 +1,557 @@
+"""Explicitly enabled, content-free aggregate usage telemetry."""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import importlib.metadata
+import os
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Mapping, Optional
+from uuid import uuid4
+
+import aiohttp
+import requests
+
+from langchain_nvidia_ai_endpoints._statics import MODEL_TABLE
+from langchain_nvidia_ai_endpoints._version import __version__
+
+_CLIENT_ID = "623344073512268"
+_EVENT_SCHEMA_VERSION = "1.0"
+_REGISTRY_SCHEMA_VERSION = "0.1"
+_EVENT_PROTOCOL = "1.6"
+_EVENT_NAME = "nim_client_usage"
+_CONNECTOR = "langchain-nvidia-ai-endpoints"
+_DEFAULT_ENDPOINT = "https://events.telemetry.data.nvidia.com/v1.1/events/json"
+_UAT_ENDPOINT = "https://events.telemetry.data-uat.nvidia.com/v1.1/events/json"
+_ALLOWED_ENDPOINTS = frozenset({_DEFAULT_ENDPOINT, _UAT_ENDPOINT})
+_ENABLED_ENV = "NVIDIA_USAGE_TELEMETRY_ENABLED"
+_ENDPOINT_ENV = "NVIDIA_USAGE_TELEMETRY_ENDPOINT"
+_MAX_COUNT = 2**31 - 1
+_MAX_TOKEN_SUM = 2**63 - 1
+_MAX_BUCKETS = 256
+
+_OPERATION_BY_CLIENT = {
+    "ChatNVIDIA": "chat",
+    "NVIDIAEmbeddings": "embedding",
+    "NVIDIARerank": "rerank",
+    "NVIDIA": "completion",
+}
+
+_APPROVED_MODEL_LOOKUP: dict[str, str] = {}
+for _approved_model in MODEL_TABLE.values():
+    _APPROVED_MODEL_LOOKUP[_approved_model.id] = _approved_model.id
+    for _alias in _approved_model.aliases or ():
+        _APPROVED_MODEL_LOOKUP[_alias] = _approved_model.id
+
+
+@dataclass(frozen=True)
+class _UsageKey:
+    window_start: str
+    connector_version: str
+    framework_version: str
+    operation: str
+    model_family: str
+    nim_id: str
+    error_category: str
+
+
+@dataclass
+class _UsageAggregate:
+    success_count: int = 0
+    failure_count: int = 0
+    request_count: int = 0
+    attempt_count: int = 0
+    input_token_sum: int = 0
+    output_token_sum: int = 0
+    missing_token_count: int = 0
+
+    def record(
+        self,
+        *,
+        success: bool,
+        input_tokens: int,
+        output_tokens: int,
+        tokens_missing: bool,
+    ) -> None:
+        self.request_count = min(_MAX_COUNT, self.request_count + 1)
+        self.attempt_count = min(_MAX_COUNT, self.attempt_count + 1)
+        if success:
+            self.success_count = min(_MAX_COUNT, self.success_count + 1)
+        else:
+            self.failure_count = min(_MAX_COUNT, self.failure_count + 1)
+        self.input_token_sum = min(
+            _MAX_TOKEN_SUM, self.input_token_sum + max(0, input_tokens)
+        )
+        self.output_token_sum = min(
+            _MAX_TOKEN_SUM, self.output_token_sum + max(0, output_tokens)
+        )
+        if tokens_missing:
+            self.missing_token_count = min(_MAX_COUNT, self.missing_token_count + 1)
+
+
+@dataclass(frozen=True)
+class _TokenUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    found: bool = False
+
+
+def usage_telemetry_enabled(value: Optional[bool] = None) -> bool:
+    """Return an explicit constructor setting or the default-off environment setting."""
+
+    if value is not None:
+        return value
+    return os.getenv(_ENABLED_ENV, "").strip().casefold() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def operation_for_client(client_name: str) -> str:
+    """Map a public client class to the approved coarse operation category."""
+
+    for prefix, operation in _OPERATION_BY_CLIENT.items():
+        if client_name.startswith(prefix):
+            return operation
+    return "other"
+
+
+def canonical_model_identity(model_name: Optional[str]) -> tuple[str, str]:
+    """Return a canonical allowlisted NIM ID and approved model-family bucket."""
+
+    canonical = _APPROVED_MODEL_LOOKUP.get(str(model_name or ""), "unknown")
+    if canonical == "unknown":
+        return "unknown", "unknown"
+    lowered = canonical.casefold()
+    if "nemotron" in lowered:
+        family = "nemotron"
+    elif "mixtral" in lowered:
+        family = "mixtral"
+    elif "mistral" in lowered:
+        family = "mistral"
+    elif "llama" in lowered:
+        family = "llama"
+    elif "gemma" in lowered:
+        family = "gemma"
+    elif "qwen" in lowered:
+        family = "qwen"
+    else:
+        family = "unknown"
+    return canonical, family
+
+
+def token_usage(value: Any) -> _TokenUsage:
+    """Extract only aggregate token counters from a known usage object."""
+
+    payload: Any = value
+    if isinstance(value, requests.Response):
+        try:
+            payload = value.json()
+        except (requests.JSONDecodeError, ValueError):
+            return _TokenUsage()
+    elif isinstance(value, str):
+        try:
+            import json
+
+            payload = json.loads(value)
+        except (TypeError, ValueError):
+            return _TokenUsage()
+    if not isinstance(payload, Mapping):
+        return _TokenUsage()
+    usage = payload.get("usage") or payload.get("usage_metadata")
+    if not isinstance(usage, Mapping):
+        return _TokenUsage()
+    input_tokens = _nonnegative_int(
+        usage.get("prompt_tokens")
+        if "prompt_tokens" in usage
+        else usage.get("input_tokens", usage.get("input_token_count"))
+    )
+    output_tokens = _nonnegative_int(
+        usage.get("completion_tokens")
+        if "completion_tokens" in usage
+        else usage.get("output_tokens", usage.get("output_token_count"))
+    )
+    found = any(
+        key in usage
+        for key in (
+            "prompt_tokens",
+            "input_tokens",
+            "input_token_count",
+            "completion_tokens",
+            "output_tokens",
+            "output_token_count",
+        )
+    )
+    return _TokenUsage(input_tokens, output_tokens, found)
+
+
+def merge_token_usage(current: _TokenUsage, candidate: _TokenUsage) -> _TokenUsage:
+    """Keep the latest cumulative usage counters observed in a stream."""
+
+    return candidate if candidate.found else current
+
+
+def classify_error(response: Any, error: BaseException) -> str:
+    """Map an error to an approved coarse category without retaining its text."""
+
+    status = getattr(response, "status_code", None)
+    if status is None:
+        status = getattr(response, "status", None)
+    if status == 401:
+        return "authentication"
+    if status == 403:
+        return "authorization"
+    if status == 408:
+        return "timeout"
+    if status == 429:
+        return "rate_limited"
+    if isinstance(status, int) and 400 <= status < 500:
+        return "provider_4xx"
+    if isinstance(status, int) and status >= 500:
+        return "provider_5xx"
+    if isinstance(error, (asyncio.CancelledError, GeneratorExit, KeyboardInterrupt)):
+        return "cancelled"
+    if isinstance(
+        error,
+        (
+            TimeoutError,
+            requests.exceptions.Timeout,
+            asyncio.TimeoutError,
+        ),
+    ):
+        return "timeout"
+    if isinstance(
+        error,
+        (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.RequestException,
+            aiohttp.ClientError,
+        ),
+    ):
+        return "network"
+    if isinstance(error, (TypeError, ValueError)):
+        return "client_validation"
+    return "unknown"
+
+
+class _UsageTelemetry:
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        post: Callable[[str, dict[str, Any]], None],
+        now: Callable[[], datetime],
+        start_worker: bool = True,
+        max_buckets: int = _MAX_BUCKETS,
+    ) -> None:
+        self._endpoint = endpoint
+        self._post = post
+        self._now = now
+        self._start_worker = start_worker
+        self._max_buckets = max(1, max_buckets)
+        self._aggregates: dict[_UsageKey, _UsageAggregate] = {}
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._wake = threading.Event()
+        self._closed = False
+
+    def record(
+        self,
+        *,
+        client_name: str,
+        model_name: Optional[str],
+        success: bool,
+        usage: _TokenUsage,
+        error_category: str = "none",
+    ) -> None:
+        now = self._now().astimezone(timezone.utc)
+        canonical_id, family = canonical_model_identity(model_name)
+        category = "none" if success else error_category
+        key = _UsageKey(
+            window_start=_hour_start(now),
+            connector_version=_version_bucket(__version__),
+            framework_version=_framework_version_bucket(),
+            operation=operation_for_client(client_name),
+            model_family=family,
+            nim_id=canonical_id,
+            error_category=category,
+        )
+        with self._lock:
+            if self._closed:
+                return
+            aggregate = self._aggregates.get(key)
+            if aggregate is None:
+                if len(self._aggregates) >= self._max_buckets:
+                    return
+                aggregate = self._aggregates[key] = _UsageAggregate()
+            aggregate.record(
+                success=success,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                tokens_missing=not usage.found,
+            )
+            if self._start_worker and self._thread is None:
+                self._thread = threading.Thread(
+                    target=self._run,
+                    name="nvidia-usage-telemetry",
+                    daemon=True,
+                )
+                self._thread.start()
+        if self._start_worker:
+            self._wake.set()
+
+    def flush(self, *, include_current: bool) -> int:
+        now = self._now().astimezone(timezone.utc)
+        current_hour = _hour_start(now)
+        with self._lock:
+            ready = [
+                (key, aggregate)
+                for key, aggregate in self._aggregates.items()
+                if include_current or key.window_start < current_hour
+            ]
+            for key, _ in ready:
+                del self._aggregates[key]
+        if not ready:
+            return 0
+        batch_id = str(uuid4())
+        events = [
+            _event_payload(key, aggregate, batch_id=batch_id)
+            for key, aggregate in ready
+        ]
+        self._post(self._endpoint, _transport_envelope(events, now=now))
+        return len(events)
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+        self._stop.set()
+        self._wake.set()
+        self.flush(include_current=True)
+        thread = self._thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=0.1)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self._wake.wait(_seconds_until_next_hour(self._now()))
+            self._wake.clear()
+            if not self._stop.is_set():
+                self.flush(include_current=False)
+
+
+_STATE: Optional[_UsageTelemetry] = None
+_STATE_LOCK = threading.Lock()
+
+
+def record_usage(
+    *,
+    enabled: bool,
+    is_hosted: bool,
+    client_name: str,
+    model_name: Optional[str],
+    success: bool,
+    usage: _TokenUsage,
+    error_category: str = "none",
+) -> None:
+    """Record one logical request without retaining request or response content."""
+
+    if not enabled or not is_hosted:
+        return
+    endpoint = _configured_endpoint()
+    if endpoint is None:
+        return
+    _get_state(endpoint).record(
+        client_name=client_name,
+        model_name=model_name,
+        success=success,
+        usage=usage,
+        error_category=error_category,
+    )
+
+
+def flush_usage_telemetry() -> int:
+    """Flush the current in-memory aggregate, primarily for controlled shutdown."""
+
+    state = _STATE
+    return state.flush(include_current=True) if state is not None else 0
+
+
+def _get_state(endpoint: str) -> _UsageTelemetry:
+    global _STATE
+    if _STATE is None:
+        with _STATE_LOCK:
+            if _STATE is None:
+                _STATE = _UsageTelemetry(
+                    endpoint=endpoint,
+                    post=_post_envelope,
+                    now=lambda: datetime.now(timezone.utc),
+                )
+    return _STATE
+
+
+def _configured_endpoint() -> Optional[str]:
+    endpoint = os.getenv(_ENDPOINT_ENV, _DEFAULT_ENDPOINT).strip()
+    return endpoint if endpoint in _ALLOWED_ENDPOINTS else None
+
+
+def _close_state() -> None:
+    state = _STATE
+    if state is not None:
+        state.close()
+
+
+def _reset_usage_telemetry_for_tests() -> None:
+    global _STATE
+    state = _STATE
+    _STATE = None
+    if state is not None:
+        state.close()
+
+
+def _post_envelope(endpoint: str, payload: dict[str, Any]) -> None:
+    timeout = _bounded_float(os.getenv("NVIDIA_USAGE_TELEMETRY_TIMEOUT_SECONDS"), 2.0)
+    for attempt in range(3):
+        try:
+            response = requests.post(
+                endpoint,
+                json=payload,
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/json;charset=utf-8",
+                    "X-Event-Protocol": _EVENT_PROTOCOL,
+                },
+                timeout=timeout,
+            )
+        except requests.exceptions.RequestException:
+            if attempt < 2:
+                time.sleep(0.1 * (2**attempt))
+            continue
+        if response.ok:
+            return
+        if response.status_code not in {408, 429} and response.status_code < 500:
+            return
+        if attempt < 2:
+            time.sleep(0.1 * (2**attempt))
+
+
+def _event_payload(
+    key: _UsageKey, aggregate: _UsageAggregate, *, batch_id: str
+) -> dict[str, Any]:
+    return {
+        "ts": _iso_timestamp(datetime.now(timezone.utc)),
+        "name": _EVENT_NAME,
+        "parameters": {
+            "eventSchemaVersion": _EVENT_SCHEMA_VERSION,
+            "windowStart": key.window_start,
+            "connector": _CONNECTOR,
+            "connectorVersion": key.connector_version,
+            "framework": "langchain",
+            "frameworkVersion": key.framework_version,
+            "operation": key.operation,
+            "modelFamily": key.model_family,
+            "nimId": key.nim_id,
+            "successCount": aggregate.success_count,
+            "failureCount": aggregate.failure_count,
+            "requestCount": aggregate.request_count,
+            "attemptCount": aggregate.attempt_count,
+            "inputTokenSum": aggregate.input_token_sum,
+            "outputTokenSum": aggregate.output_token_sum,
+            "missingTokenCount": aggregate.missing_token_count,
+            "errorCategory": key.error_category,
+            "batchId": batch_id,
+        },
+    }
+
+
+def _transport_envelope(
+    events: list[dict[str, Any]], *, now: datetime
+) -> dict[str, Any]:
+    return {
+        "clientId": _CLIENT_ID,
+        "eventSchemaVer": _REGISTRY_SCHEMA_VERSION,
+        "eventProtocol": _EVENT_PROTOCOL,
+        "sentTs": _iso_timestamp(now),
+        "clientVer": "1.0.0.0",
+        "integrationId": "undefined",
+        "clientType": "Native",
+        "clientVariant": "Release",
+        "browserType": "undefined",
+        "userId": "undefined",
+        "externalUserId": "undefined",
+        "idpId": "undefined",
+        "sessionId": "undefined",
+        "eventSysVer": "1.0.0.0",
+        "deviceId": "undefined",
+        "cpuArchitecture": "undefined",
+        "deviceOS": "undefined",
+        "deviceOSVersion": "undefined",
+        "deviceType": "undefined",
+        "deviceMake": "undefined",
+        "deviceModel": "undefined",
+        "productName": "undefined",
+        "productVersion": "undefined",
+        "gdprTechOptIn": "None",
+        "gdprBehOptIn": "None",
+        "gdprFuncOptIn": "Full",
+        "deviceGdprTechOptIn": "None",
+        "deviceGdprBehOptIn": "None",
+        "deviceGdprFuncOptIn": "None",
+        "events": events,
+    }
+
+
+def _framework_version_bucket() -> str:
+    try:
+        return _version_bucket(importlib.metadata.version("langchain-core"))
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _version_bucket(value: str) -> str:
+    parts = value.strip().split(".")
+    if len(parts) < 2 or not parts[0].isdigit() or not parts[1].isdigit():
+        return "unknown"
+    return f"{int(parts[0])}.{int(parts[1])}"
+
+
+def _hour_start(value: datetime) -> str:
+    value = value.astimezone(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    return value.strftime("%Y-%m-%dT%H:00:00Z")
+
+
+def _seconds_until_next_hour(value: datetime) -> float:
+    value = value.astimezone(timezone.utc)
+    next_hour = value.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    return max(0.1, (next_hour - value).total_seconds())
+
+
+def _iso_timestamp(value: datetime) -> str:
+    value = value.astimezone(timezone.utc)
+    return value.strftime("%Y-%m-%dT%H:%M:%S.") + f"{value.microsecond // 1000:03d}Z"
+
+
+def _nonnegative_int(value: Any) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bounded_float(value: Optional[str], default: float) -> float:
+    try:
+        parsed = float(value) if value is not None else default
+    except ValueError:
+        parsed = default
+    return min(10.0, max(0.1, parsed))
+
+
+atexit.register(_close_state)

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_telemetry.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/_telemetry.py
@@ -1,4 +1,4 @@
-"""Explicitly enabled, content-free aggregate usage telemetry."""
+"""Content-free aggregate usage telemetry with process and client opt-out."""
 
 from __future__ import annotations
 
@@ -31,6 +31,7 @@ _UAT_ENDPOINT = "https://events.telemetry.data-uat.nvidia.com/v1.1/events/json"
 _ALLOWED_ENDPOINTS = frozenset({_DEFAULT_ENDPOINT, _UAT_ENDPOINT})
 _ENABLED_ENV = "NVIDIA_USAGE_TELEMETRY_ENABLED"
 _ENDPOINT_ENV = "NVIDIA_USAGE_TELEMETRY_ENDPOINT"
+_DISABLED_VALUES = {"0", "false", "no", "off"}
 _MAX_COUNT = 2**31 - 1
 _MAX_TOKEN_SUM = 2**63 - 1
 _MAX_BUCKETS = 256
@@ -176,16 +177,11 @@ class _TransportDelivery:
 
 
 def usage_telemetry_enabled(value: Optional[bool] = None) -> bool:
-    """Return an explicit constructor setting or the default-off environment setting."""
+    """Return an explicit constructor setting or the default-on environment setting."""
 
     if value is not None:
         return value
-    return os.getenv(_ENABLED_ENV, "").strip().casefold() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
+    return os.getenv(_ENABLED_ENV, "").strip().casefold() not in _DISABLED_VALUES
 
 
 def operation_for_client(client_name: str) -> str:

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -382,6 +382,15 @@ class ChatNVIDIA(BaseChatModel):
         description="Default headers merged into all requests.",
     )
 
+    usage_telemetry_enabled: Optional[bool] = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Enable content-free aggregate usage telemetry. Disabled by default."
+        ),
+    )
+
     model_kwargs: Dict[str, Any] = Field(
         default_factory=dict,
         description=(
@@ -441,6 +450,10 @@ class ChatNVIDIA(BaseChatModel):
             seed: A seed for deterministic results.
             stop: A string or list of strings specifying stop sequences.
             default_headers: Default headers merged into all requests.
+            usage_telemetry_enabled: Enable content-free hourly usage aggregates for
+                NVIDIA-hosted NIMs. Disabled by default. The
+                `NVIDIA_USAGE_TELEMETRY_ENABLED` environment variable provides the
+                default when this argument is omitted.
             **kwargs: Additional parameters passed to the underlying client.
 
         The recommended way to provide the API key is through the `NVIDIA_API_KEY`
@@ -516,6 +529,11 @@ class ChatNVIDIA(BaseChatModel):
             cls="ChatNVIDIA",
             verify_ssl=verify_ssl,
             **({"timeout": timeout} if timeout is not None else {}),
+            **(
+                {"usage_telemetry_enabled": self.usage_telemetry_enabled}
+                if self.usage_telemetry_enabled is not None
+                else {}
+            ),
         )
         # todo: only store the model in one place
         # the model may be updated to a newer name during initialization

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -894,9 +894,9 @@ class ChatNVIDIA(BaseChatModel):
             }
         # "tool_calls" is set for invoke and stream responses
         if tool_calls := kw_left.pop("tool_calls", None):
-            assert isinstance(tool_calls, list), (
-                "invalid response from server: tool_calls must be a list"
-            )
+            assert isinstance(
+                tool_calls, list
+            ), "invalid response from server: tool_calls must be a list"
             # todo: break this into post-processing for invoke and stream
             if not streaming:
                 out_dict["additional_kwargs"]["tool_calls"] = tool_calls

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/chat_models.py
@@ -387,7 +387,8 @@ class ChatNVIDIA(BaseChatModel):
         exclude=True,
         repr=False,
         description=(
-            "Enable content-free aggregate usage telemetry. Disabled by default."
+            "Enable content-free aggregate usage telemetry. Enabled by default "
+            "unless disabled."
         ),
     )
 
@@ -451,7 +452,7 @@ class ChatNVIDIA(BaseChatModel):
             stop: A string or list of strings specifying stop sequences.
             default_headers: Default headers merged into all requests.
             usage_telemetry_enabled: Enable content-free hourly usage aggregates for
-                NVIDIA-hosted NIMs. Disabled by default. The
+                NVIDIA-hosted NIMs. Enabled by default unless disabled. The
                 `NVIDIA_USAGE_TELEMETRY_ENABLED` environment variable provides the
                 default when this argument is omitted.
             **kwargs: Additional parameters passed to the underlying client.
@@ -893,9 +894,9 @@ class ChatNVIDIA(BaseChatModel):
             }
         # "tool_calls" is set for invoke and stream responses
         if tool_calls := kw_left.pop("tool_calls", None):
-            assert isinstance(
-                tool_calls, list
-            ), "invalid response from server: tool_calls must be a list"
+            assert isinstance(tool_calls, list), (
+                "invalid response from server: tool_calls must be a list"
+            )
             # todo: break this into post-processing for invoke and stream
             if not streaming:
                 out_dict["additional_kwargs"]["tool_calls"] = tool_calls

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
@@ -72,6 +72,15 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
         description="Default headers merged into all requests.",
     )
 
+    usage_telemetry_enabled: Optional[bool] = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Enable content-free aggregate usage telemetry. Disabled by default."
+        ),
+    )
+
     def __init__(
         self,
         *,
@@ -103,6 +112,8 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
                 an error if an input is too long.
             dimensions: The number of dimensions for the embeddings. This
                 parameter is not supported by all models.
+            usage_telemetry_enabled: Enable content-free hourly usage aggregates for
+                NVIDIA-hosted NIMs. Disabled by default.
             **kwargs: Additional parameters passed to the underlying client.
 
         The recommended way to provide the API key is through the `NVIDIA_API_KEY`
@@ -148,6 +159,11 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
             infer_path="{base_url}/embeddings",
             cls=self.__class__.__name__,
             verify_ssl=verify_ssl,
+            **(
+                {"usage_telemetry_enabled": self.usage_telemetry_enabled}
+                if self.usage_telemetry_enabled is not None
+                else {}
+            ),
         )
 
         # todo: only store the model in one place

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/embeddings.py
@@ -77,7 +77,8 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
         exclude=True,
         repr=False,
         description=(
-            "Enable content-free aggregate usage telemetry. Disabled by default."
+            "Enable content-free aggregate usage telemetry. Enabled by default "
+            "unless disabled."
         ),
     )
 
@@ -113,7 +114,7 @@ class NVIDIAEmbeddings(BaseModel, Embeddings):
             dimensions: The number of dimensions for the embeddings. This
                 parameter is not supported by all models.
             usage_telemetry_enabled: Enable content-free hourly usage aggregates for
-                NVIDIA-hosted NIMs. Disabled by default.
+                NVIDIA-hosted NIMs. Enabled by default unless disabled.
             **kwargs: Additional parameters passed to the underlying client.
 
         The recommended way to provide the API key is through the `NVIDIA_API_KEY`

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/llm.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/llm.py
@@ -43,6 +43,15 @@ class NVIDIA(LLM):
 
     model: Optional[str] = Field(None, description="The model to use for completions.")
 
+    usage_telemetry_enabled: Optional[bool] = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Enable content-free aggregate usage telemetry. Disabled by default."
+        ),
+    )
+
     _init_args: Dict[str, Any] = PrivateAttr()
     """Stashed arguments given to the constructor that can be passed to
     the Completions API endpoint."""
@@ -100,6 +109,8 @@ class NVIDIA(LLM):
         Args:
             nvidia_api_key: The API key to use for connecting to the hosted NIM.
             api_key: Alternative to `nvidia_api_key`.
+            usage_telemetry_enabled: Enable content-free hourly usage aggregates for
+                NVIDIA-hosted NIMs. Disabled by default.
             **kwargs: Additional parameters passed to the underlying client.
 
         The recommended way to provide the API key is through the `NVIDIA_API_KEY`
@@ -138,6 +149,11 @@ class NVIDIA(LLM):
             infer_path="{base_url}/completions",
             cls=self.__class__.__name__,
             verify_ssl=verify_ssl,
+            **(
+                {"usage_telemetry_enabled": self.usage_telemetry_enabled}
+                if self.usage_telemetry_enabled is not None
+                else {}
+            ),
         )
         # todo: only store the model in one place
         # the model may be updated to a newer name during initialization
@@ -151,6 +167,7 @@ class NVIDIA(LLM):
             "model",
             "nvidia_base_url",
             "base_url",
+            "usage_telemetry_enabled",
         ]:
             if key in kwargs:
                 del kwargs[key]

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/llm.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/llm.py
@@ -48,7 +48,8 @@ class NVIDIA(LLM):
         exclude=True,
         repr=False,
         description=(
-            "Enable content-free aggregate usage telemetry. Disabled by default."
+            "Enable content-free aggregate usage telemetry. Enabled by default "
+            "unless disabled."
         ),
     )
 
@@ -110,7 +111,7 @@ class NVIDIA(LLM):
             nvidia_api_key: The API key to use for connecting to the hosted NIM.
             api_key: Alternative to `nvidia_api_key`.
             usage_telemetry_enabled: Enable content-free hourly usage aggregates for
-                NVIDIA-hosted NIMs. Disabled by default.
+                NVIDIA-hosted NIMs. Enabled by default unless disabled.
             **kwargs: Additional parameters passed to the underlying client.
 
         The recommended way to provide the API key is through the `NVIDIA_API_KEY`

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
@@ -72,6 +72,15 @@ class NVIDIARerank(BaseDocumentCompressor):
         description="Default headers merged into all requests.",
     )
 
+    usage_telemetry_enabled: Optional[bool] = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Enable content-free aggregate usage telemetry. Disabled by default."
+        ),
+    )
+
     extra_headers: dict = Field(
         default_factory=dict,
         description="Deprecated: Use 'default_headers' instead. "
@@ -96,6 +105,8 @@ class NVIDIARerank(BaseDocumentCompressor):
         Args:
             nvidia_api_key: The API key to use for connecting to the hosted NIM.
             api_key: Alternative to `nvidia_api_key`.
+            usage_telemetry_enabled: Enable content-free hourly usage aggregates for
+                NVIDIA-hosted NIMs. Disabled by default.
             **kwargs: Additional parameters passed to the underlying client.
 
         The recommended way to provide the API key is through the `NVIDIA_API_KEY`
@@ -218,6 +229,11 @@ class NVIDIARerank(BaseDocumentCompressor):
             infer_path="{base_url}/ranking",
             cls=self.__class__.__name__,
             verify_ssl=verify_ssl,
+            **(
+                {"usage_telemetry_enabled": self.usage_telemetry_enabled}
+                if self.usage_telemetry_enabled is not None
+                else {}
+            ),
         )
 
         # todo: only store the model in one place

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
@@ -339,9 +339,9 @@ class NVIDIARerank(BaseDocumentCompressor):
             results: List to append processed documents to
         """
         for ranking in rankings:
-            assert 0 <= ranking.index < len(doc_batch), (
-                "invalid response from server: index out of range"
-            )
+            assert (
+                0 <= ranking.index < len(doc_batch)
+            ), "invalid response from server: index out of range"
             doc = doc_batch[ranking.index]
             doc.metadata["relevance_score"] = ranking.logit
             results.append(doc)

--- a/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
+++ b/libs/ai-endpoints/langchain_nvidia_ai_endpoints/reranking.py
@@ -77,7 +77,8 @@ class NVIDIARerank(BaseDocumentCompressor):
         exclude=True,
         repr=False,
         description=(
-            "Enable content-free aggregate usage telemetry. Disabled by default."
+            "Enable content-free aggregate usage telemetry. Enabled by default "
+            "unless disabled."
         ),
     )
 
@@ -106,7 +107,7 @@ class NVIDIARerank(BaseDocumentCompressor):
             nvidia_api_key: The API key to use for connecting to the hosted NIM.
             api_key: Alternative to `nvidia_api_key`.
             usage_telemetry_enabled: Enable content-free hourly usage aggregates for
-                NVIDIA-hosted NIMs. Disabled by default.
+                NVIDIA-hosted NIMs. Enabled by default unless disabled.
             **kwargs: Additional parameters passed to the underlying client.
 
         The recommended way to provide the API key is through the `NVIDIA_API_KEY`
@@ -338,9 +339,9 @@ class NVIDIARerank(BaseDocumentCompressor):
             results: List to append processed documents to
         """
         for ranking in rankings:
-            assert (
-                0 <= ranking.index < len(doc_batch)
-            ), "invalid response from server: index out of range"
+            assert 0 <= ranking.index < len(doc_batch), (
+                "invalid response from server: index out of range"
+            )
             doc = doc_batch[ranking.index]
             doc.metadata["relevance_score"] = ranking.logit
             results.append(doc)

--- a/libs/ai-endpoints/tests/data/nim_client_usage_schema.json
+++ b/libs/ai-endpoints/tests/data/nim_client_usage_schema.json
@@ -1,0 +1,249 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaMeta": {
+    "schemaVersion": "0.1",
+    "clientId": "623344073512268",
+    "clientName": "NIM_OSS",
+    "definitionVersion": "1.0",
+    "personalization": ""
+  },
+  "description": "Privacy-safe aggregate usage telemetry for NVIDIA NIM integrations in supported open-source connector libraries.",
+  "definitions": {
+    "types": {
+      "NimFrameworkEnum": {
+        "type": "string",
+        "description": "Closed framework ID; unknown is used when an approved mapping is unavailable.",
+        "enum": [
+          "langchain",
+          "unknown"
+        ]
+      },
+      "NimOperationEnum": {
+        "type": "string",
+        "description": "Coarse logical operation category.",
+        "enum": [
+          "chat",
+          "completion",
+          "embedding",
+          "rerank",
+          "retrieval",
+          "other"
+        ]
+      },
+      "NimModelFamilyEnum": {
+        "type": "string",
+        "description": "Versioned, approved model-family classification; never a raw model name or endpoint value.",
+        "enum": [
+          "llama",
+          "mistral",
+          "mixtral",
+          "gemma",
+          "qwen",
+          "nemotron",
+          "unknown"
+        ]
+      },
+      "NimErrorCategoryEnum": {
+        "type": "string",
+        "description": "Coarse final logical outcome category; transient retry errors are not reported.",
+        "enum": [
+          "none",
+          "authentication",
+          "authorization",
+          "rate_limited",
+          "timeout",
+          "network",
+          "provider_4xx",
+          "provider_5xx",
+          "client_validation",
+          "cancelled",
+          "unknown"
+        ]
+      },
+      "NimVersionBucket": {
+        "type": "string",
+        "description": "Major.minor version bucket without package, prerelease, build, or patch identifiers.",
+        "maxLength": 32,
+        "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+      },
+      "NimFrameworkVersionBucket": {
+        "type": "string",
+        "description": "Major.minor framework version bucket or unknown when an approved mapping is unavailable.",
+        "maxLength": 32,
+        "pattern": "^(unknown|(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*))$"
+      },
+      "NimUtcHour": {
+        "type": "string",
+        "description": "UTC aggregation window rounded to the hour with no per-invocation timestamp.",
+        "maxLength": 20,
+        "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):00:00Z$"
+      },
+      "NimBatchId": {
+        "type": "string",
+        "description": "Ephemeral random UUIDv4 generated once per transmission batch for bounded deduplication; never persisted, reused, or joined to identity-bearing data.",
+        "maxLength": 36,
+        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+      },
+      "NimAggregateCount": {
+        "type": "integer",
+        "description": "Bounded nonnegative aggregate count.",
+        "minimum": 0,
+        "maximum": 2147483647
+      },
+      "NimPositiveAggregateCount": {
+        "type": "integer",
+        "description": "Bounded positive aggregate count.",
+        "minimum": 1,
+        "maximum": 2147483647
+      },
+      "NimTokenSum": {
+        "type": "integer",
+        "description": "Bounded nonnegative aggregate token sum; collection remains subject to privacy approval.",
+        "minimum": 0,
+        "maximum": 9223372036854775807
+      }
+    },
+    "events": {
+      "nim_client_usage": {
+        "description": "Hourly aggregate for explicitly enabled NIM OSS connector usage. Contains no content, endpoint details, arbitrary strings, or durable user, device, installation, or session identifiers.",
+        "type": "object",
+        "eventMeta": {
+          "service": "telemetry",
+          "gdpr": {
+            "category": "functional",
+            "description": "Content-free, identity-free aggregate metadata with ephemeral transmission-batch deduplication.",
+            "personalization": ""
+          }
+        },
+        "properties": {
+          "eventSchemaVersion": {
+            "type": "string",
+            "description": "Version of the nim_client_usage event contract, independent of the registry schema version.",
+            "const": "1.0"
+          },
+          "windowStart": {
+            "$ref": "#/definitions/types/NimUtcHour"
+          },
+          "connector": {
+            "type": "string",
+            "description": "The only connector in the approval-gated MVP.",
+            "const": "langchain-nvidia-ai-endpoints"
+          },
+          "connectorVersion": {
+            "$ref": "#/definitions/types/NimVersionBucket"
+          },
+          "framework": {
+            "$ref": "#/definitions/types/NimFrameworkEnum"
+          },
+          "frameworkVersion": {
+            "$ref": "#/definitions/types/NimFrameworkVersionBucket"
+          },
+          "operation": {
+            "$ref": "#/definitions/types/NimOperationEnum"
+          },
+          "modelFamily": {
+            "$ref": "#/definitions/types/NimModelFamilyEnum"
+          },
+          "nimId": {
+            "type": "string",
+            "description": "Canonical public NIM identifier emitted only after an exact match to the connector's versioned allowlist; raw and unrecognized model inputs map to 'unknown'.",
+            "maxLength": 192,
+            "pattern": "^(unknown|[A-Za-z0-9][A-Za-z0-9._-]{0,63}/[A-Za-z0-9][A-Za-z0-9._-]{0,126})$"
+          },
+          "successCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "failureCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "requestCount": {
+            "$ref": "#/definitions/types/NimPositiveAggregateCount"
+          },
+          "attemptCount": {
+            "$ref": "#/definitions/types/NimPositiveAggregateCount"
+          },
+          "inputTokenSum": {
+            "$ref": "#/definitions/types/NimTokenSum"
+          },
+          "outputTokenSum": {
+            "$ref": "#/definitions/types/NimTokenSum"
+          },
+          "missingTokenCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "errorCategory": {
+            "$ref": "#/definitions/types/NimErrorCategoryEnum"
+          },
+          "batchId": {
+            "$ref": "#/definitions/types/NimBatchId"
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "errorCategory": {
+                  "const": "none"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "failureCount": {
+                  "const": 0
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "errorCategory": {
+                  "not": {
+                    "const": "none"
+                  }
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "successCount": {
+                  "const": 0
+                },
+                "failureCount": {
+                  "minimum": 1
+                }
+              }
+            }
+          }
+        ],
+        "additionalProperties": false,
+        "required": [
+          "eventSchemaVersion",
+          "windowStart",
+          "connector",
+          "connectorVersion",
+          "framework",
+          "frameworkVersion",
+          "operation",
+          "modelFamily",
+          "nimId",
+          "successCount",
+          "failureCount",
+          "requestCount",
+          "attemptCount",
+          "inputTokenSum",
+          "outputTokenSum",
+          "missingTokenCount",
+          "errorCategory",
+          "batchId"
+        ]
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/definitions/events/nim_client_usage"
+    }
+  ]
+}

--- a/libs/ai-endpoints/tests/data/nim_client_usage_schema.json
+++ b/libs/ai-endpoints/tests/data/nim_client_usage_schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "schemaMeta": {
-    "schemaVersion": "0.1",
+    "schemaVersion": "0.2",
     "clientId": "623344073512268",
     "clientName": "NIM_OSS",
     "definitionVersion": "1.0",
@@ -101,6 +101,137 @@
         "description": "Bounded nonnegative aggregate token sum; collection remains subject to privacy approval.",
         "minimum": 0,
         "maximum": 9223372036854775807
+      },
+      "NimExecutionModeEnum": {
+        "type": "string",
+        "description": "Closed execution mode for the logical connector invocation.",
+        "enum": [
+          "sync",
+          "async",
+          "streaming",
+          "batch",
+          "other",
+          "unknown"
+        ]
+      },
+      "NimErrorCategoryCounts": {
+        "type": "object",
+        "description": "Closed error category counts for this aggregate window.",
+        "additionalProperties": false,
+        "properties": {
+          "authentication": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "authorization": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "rate_limited": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "timeout": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "network": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "provider_4xx": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "provider_5xx": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "client_validation": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "cancelled": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "unknown": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          }
+        },
+        "required": [
+          "authentication",
+          "authorization",
+          "rate_limited",
+          "timeout",
+          "network",
+          "provider_4xx",
+          "provider_5xx",
+          "client_validation",
+          "cancelled",
+          "unknown"
+        ]
+      },
+      "NimHttpStatusClassCounts": {
+        "type": "object",
+        "description": "Closed HTTP response status-class counts; no status code, response body, or exception text.",
+        "additionalProperties": false,
+        "properties": {
+          "2xx": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "4xx": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "5xx": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "none": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "unknown": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          }
+        },
+        "required": [
+          "2xx",
+          "4xx",
+          "5xx",
+          "none",
+          "unknown"
+        ]
+      },
+      "NimLatencyBucketCounts": {
+        "type": "object",
+        "description": "Versioned aggregate latency histogram counts; no raw duration values.",
+        "additionalProperties": false,
+        "properties": {
+          "le_100_ms": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "le_250_ms": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "le_500_ms": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "le_1000_ms": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "le_2500_ms": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "le_5000_ms": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "le_10000_ms": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "gt_10000_ms": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          }
+        },
+        "required": [
+          "le_100_ms",
+          "le_250_ms",
+          "le_500_ms",
+          "le_1000_ms",
+          "le_2500_ms",
+          "le_5000_ms",
+          "le_10000_ms",
+          "gt_10000_ms"
+        ]
       }
     },
     "events": {
@@ -124,6 +255,9 @@
           "windowStart": {
             "$ref": "#/definitions/types/NimUtcHour"
           },
+          "telemetryClientVersion": {
+            "$ref": "#/definitions/types/NimVersionBucket"
+          },
           "connector": {
             "type": "string",
             "description": "The only connector in the approval-gated MVP.",
@@ -141,6 +275,9 @@
           "operation": {
             "$ref": "#/definitions/types/NimOperationEnum"
           },
+          "executionMode": {
+            "$ref": "#/definitions/types/NimExecutionModeEnum"
+          },
           "modelFamily": {
             "$ref": "#/definitions/types/NimModelFamilyEnum"
           },
@@ -156,11 +293,23 @@
           "failureCount": {
             "$ref": "#/definitions/types/NimAggregateCount"
           },
+          "cancelledCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "partialCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
           "requestCount": {
             "$ref": "#/definitions/types/NimPositiveAggregateCount"
           },
           "attemptCount": {
             "$ref": "#/definitions/types/NimPositiveAggregateCount"
+          },
+          "retriedRequestCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "firstAttemptSuccessCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
           },
           "inputTokenSum": {
             "$ref": "#/definitions/types/NimTokenSum"
@@ -171,8 +320,35 @@
           "missingTokenCount": {
             "$ref": "#/definitions/types/NimAggregateCount"
           },
+          "missingTokenAttemptCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
           "errorCategory": {
             "$ref": "#/definitions/types/NimErrorCategoryEnum"
+          },
+          "errorCategoryCounts": {
+            "$ref": "#/definitions/types/NimErrorCategoryCounts"
+          },
+          "httpStatusClassCounts": {
+            "$ref": "#/definitions/types/NimHttpStatusClassCounts"
+          },
+          "latencyBucketCounts": {
+            "$ref": "#/definitions/types/NimLatencyBucketCounts"
+          },
+          "ttftBucketCounts": {
+            "$ref": "#/definitions/types/NimLatencyBucketCounts"
+          },
+          "missingTtftCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "clientDropCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "transportRetryCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
+          },
+          "priorTerminalSendFailureCount": {
+            "$ref": "#/definitions/types/NimAggregateCount"
           },
           "batchId": {
             "$ref": "#/definitions/types/NimBatchId"
@@ -219,25 +395,40 @@
         ],
         "additionalProperties": false,
         "required": [
-          "eventSchemaVersion",
-          "windowStart",
-          "connector",
-          "connectorVersion",
-          "framework",
-          "frameworkVersion",
-          "operation",
-          "modelFamily",
-          "nimId",
-          "successCount",
-          "failureCount",
-          "requestCount",
-          "attemptCount",
-          "inputTokenSum",
-          "outputTokenSum",
-          "missingTokenCount",
-          "errorCategory",
-          "batchId"
-        ]
+            "eventSchemaVersion",
+            "windowStart",
+            "telemetryClientVersion",
+            "connector",
+            "connectorVersion",
+            "framework",
+            "frameworkVersion",
+            "operation",
+            "executionMode",
+            "modelFamily",
+            "nimId",
+            "successCount",
+            "failureCount",
+            "cancelledCount",
+            "partialCount",
+            "requestCount",
+            "attemptCount",
+            "retriedRequestCount",
+            "firstAttemptSuccessCount",
+            "inputTokenSum",
+            "outputTokenSum",
+            "missingTokenCount",
+            "missingTokenAttemptCount",
+            "errorCategory",
+            "errorCategoryCounts",
+            "httpStatusClassCounts",
+            "latencyBucketCounts",
+            "ttftBucketCounts",
+            "missingTtftCount",
+            "clientDropCount",
+            "transportRetryCount",
+            "priorTerminalSendFailureCount",
+            "batchId"
+          ]
       }
     }
   },

--- a/libs/ai-endpoints/tests/data/nim_client_usage_schema.json
+++ b/libs/ai-endpoints/tests/data/nim_client_usage_schema.json
@@ -236,7 +236,7 @@
     },
     "events": {
       "nim_client_usage": {
-        "description": "Hourly aggregate for explicitly enabled NIM OSS connector usage. Contains no content, endpoint details, arbitrary strings, or durable user, device, installation, or session identifiers.",
+        "description": "Hourly aggregate for NIM OSS connector usage. Contains no content, endpoint details, arbitrary strings, or durable user, device, installation, or session identifiers.",
         "type": "object",
         "eventMeta": {
           "service": "telemetry",

--- a/libs/ai-endpoints/tests/unit_tests/test_usage_telemetry.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_usage_telemetry.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, AsyncGenerator, Generator, cast
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+import requests
+
+from langchain_nvidia_ai_endpoints._common import (
+    _NVIDIAAsyncClient,
+    _NVIDIASyncClient,
+)
+from langchain_nvidia_ai_endpoints._telemetry import (
+    _post_envelope,
+    _TokenUsage,
+    _UsageTelemetry,
+    canonical_model_identity,
+    classify_error,
+    flush_usage_telemetry,
+    merge_token_usage,
+    operation_for_client,
+    record_usage,
+    token_usage,
+    usage_telemetry_enabled,
+)
+from langchain_nvidia_ai_endpoints.chat_models import ChatNVIDIA
+from langchain_nvidia_ai_endpoints.embeddings import NVIDIAEmbeddings
+from langchain_nvidia_ai_endpoints.llm import NVIDIA
+from langchain_nvidia_ai_endpoints.reranking import NVIDIARerank
+
+
+@pytest.fixture(autouse=True)
+def reset_global_telemetry() -> Generator[None, None, None]:
+    from langchain_nvidia_ai_endpoints import _telemetry
+
+    _telemetry._reset_usage_telemetry_for_tests()
+    yield
+    _telemetry._reset_usage_telemetry_for_tests()
+
+
+def _sync_client(**overrides: Any) -> _NVIDIASyncClient:
+    values: dict[str, Any] = {
+        "default_hosted_model_name": "nvidia/nemotron-3.5-lightning-30b-a3b",
+        "mdl_name": "nvidia/nemotron-3.5-lightning-30b-a3b",
+        "model": None,
+        "is_hosted": True,
+        "cls": "ChatNVIDIA",
+        "infer_path": "{base_url}/chat/completions",
+        "usage_telemetry_enabled": True,
+    }
+    values.update(overrides)
+    return _NVIDIASyncClient(**values)
+
+
+def _async_client(**overrides: Any) -> _NVIDIAAsyncClient:
+    values: dict[str, Any] = {
+        "default_hosted_model_name": "nvidia/nemotron-3.5-lightning-30b-a3b",
+        "mdl_name": "nvidia/nemotron-3.5-lightning-30b-a3b",
+        "model": None,
+        "is_hosted": True,
+        "cls": "ChatNVIDIA",
+        "infer_path": "{base_url}/chat/completions",
+        "usage_telemetry_enabled": True,
+    }
+    values.update(overrides)
+    return _NVIDIAAsyncClient(**values)
+
+
+def _response(status: int = 200, payload: dict | None = None) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status
+    response._content = json.dumps(payload or {}).encode("utf-8")
+    return response
+
+
+def test_usage_telemetry_is_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NVIDIA_USAGE_TELEMETRY_ENABLED", raising=False)
+    assert usage_telemetry_enabled() is False
+    assert usage_telemetry_enabled(False) is False
+    assert usage_telemetry_enabled(True) is True
+
+    monkeypatch.setenv("NVIDIA_USAGE_TELEMETRY_ENABLED", "true")
+    assert usage_telemetry_enabled() is True
+
+
+def test_canonical_model_identity_uses_versioned_static_allowlist() -> None:
+    assert canonical_model_identity("nvidia/nemotron-3.5-lightning-30b-a3b") == (
+        "nvidia/nemotron-3.5-lightning-30b-a3b",
+        "nemotron",
+    )
+    assert canonical_model_identity("ai-mixtral-8x7b-instruct") == (
+        "mistralai/mixtral-8x7b-instruct-v0.1",
+        "mixtral",
+    )
+    assert canonical_model_identity("private/raw-model-name") == ("unknown", "unknown")
+
+
+def test_operation_mapping_is_closed() -> None:
+    assert operation_for_client("ChatNVIDIA") == "chat"
+    assert operation_for_client("ChatNVIDIACustom") == "chat"
+    assert operation_for_client("NVIDIA") == "completion"
+    assert operation_for_client("NVIDIAEmbeddings") == "embedding"
+    assert operation_for_client("NVIDIARerank") == "rerank"
+    assert operation_for_client("UnrecognizedClient") == "other"
+
+
+def test_token_usage_reads_only_known_aggregate_fields() -> None:
+    usage = token_usage(
+        {
+            "choices": [{"message": {"content": "private response"}}],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 7},
+        }
+    )
+    assert usage == _TokenUsage(input_tokens=12, output_tokens=7, found=True)
+    assert merge_token_usage(_TokenUsage(), usage) == usage
+    assert token_usage({"usage": {}}) == _TokenUsage()
+
+
+def test_error_classification_uses_status_and_exception_type() -> None:
+    assert (
+        classify_error(SimpleNamespace(status_code=401), Exception("secret"))
+        == "authentication"
+    )
+    assert (
+        classify_error(SimpleNamespace(status_code=403), Exception("secret"))
+        == "authorization"
+    )
+    assert (
+        classify_error(SimpleNamespace(status_code=429), Exception("secret"))
+        == "rate_limited"
+    )
+    assert (
+        classify_error(SimpleNamespace(status_code=503), Exception("secret"))
+        == "provider_5xx"
+    )
+    assert classify_error(None, TimeoutError("secret")) == "timeout"
+    assert classify_error(None, requests.ConnectionError("secret")) == "network"
+    assert classify_error(None, ValueError("private prompt")) == "client_validation"
+
+
+def test_aggregate_flush_matches_schema_and_has_no_identity_values() -> None:
+    captured: list[dict] = []
+    fixed_now = datetime(2026, 8, 28, 14, 30, tzinfo=timezone.utc)
+    state = _UsageTelemetry(
+        endpoint="https://events.example.test/v1.1/events/json",
+        post=lambda endpoint, payload: captured.append(payload),
+        now=lambda: fixed_now,
+        start_worker=False,
+    )
+    state.record(
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(100, 50, True),
+    )
+    state.record(
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(20, 10, True),
+    )
+    state.record(
+        client_name="ChatNVIDIA",
+        model_name="private/model",
+        success=False,
+        usage=_TokenUsage(),
+        error_category="authorization",
+    )
+
+    assert state.flush(include_current=True) == 2
+    assert len(captured) == 1
+    envelope = captured[0]
+    assert envelope["clientId"] == "623344073512268"
+    assert envelope["eventSchemaVer"] == "0.1"
+    for field in ("userId", "externalUserId", "idpId", "sessionId", "deviceId"):
+        assert envelope[field] == "undefined"
+
+    events = envelope["events"]
+    assert {event["name"] for event in events} == {"nim_client_usage"}
+    assert len({event["parameters"]["batchId"] for event in events}) == 1
+    success = next(
+        event["parameters"]
+        for event in events
+        if event["parameters"]["errorCategory"] == "none"
+    )
+    assert success["requestCount"] == 2
+    assert success["successCount"] == 2
+    assert success["failureCount"] == 0
+    assert success["inputTokenSum"] == 120
+    assert success["outputTokenSum"] == 60
+    failure = next(
+        event["parameters"]
+        for event in events
+        if event["parameters"]["errorCategory"] == "authorization"
+    )
+    assert failure["nimId"] == "unknown"
+    assert failure["modelFamily"] == "unknown"
+    assert failure["successCount"] == 0
+    assert failure["failureCount"] == 1
+    assert failure["missingTokenCount"] == 1
+
+    schema = json.loads(
+        (
+            Path(__file__).parents[1] / "data" / "nim_client_usage_schema.json"
+        ).read_text()
+    )
+    required = set(schema["definitions"]["events"]["nim_client_usage"]["required"])
+    for event in events:
+        assert set(event["parameters"]) == required
+    serialized = json.dumps(envelope)
+    for forbidden in (
+        "private prompt",
+        "private response",
+        "endpoint_url",
+        "hostname",
+        "exception",
+        "credential",
+    ):
+        assert forbidden not in serialized
+
+
+def test_aggregate_bucket_count_is_bounded() -> None:
+    captured: list[dict] = []
+    state = _UsageTelemetry(
+        endpoint="https://events.example.test/v1.1/events/json",
+        post=lambda endpoint, payload: captured.append(payload),
+        now=lambda: datetime(2026, 8, 28, 14, 30, tzinfo=timezone.utc),
+        start_worker=False,
+        max_buckets=1,
+    )
+    state.record(
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(found=False),
+    )
+    state.record(
+        client_name="NVIDIAEmbeddings",
+        model_name="nvidia/nv-embedqa-e5-v5",
+        success=True,
+        usage=_TokenUsage(found=False),
+    )
+
+    assert state.flush(include_current=True) == 1
+    assert len(captured[0]["events"]) == 1
+
+
+def test_disabled_and_self_hosted_records_do_not_create_global_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from langchain_nvidia_ai_endpoints import _telemetry
+
+    record_usage(
+        enabled=False,
+        is_hosted=True,
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(found=False),
+    )
+    record_usage(
+        enabled=True,
+        is_hosted=False,
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(found=False),
+    )
+    monkeypatch.setenv(
+        "NVIDIA_USAGE_TELEMETRY_ENDPOINT", "https://unapproved.example.test/events"
+    )
+    record_usage(
+        enabled=True,
+        is_hosted=True,
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(found=False),
+    )
+    assert _telemetry._STATE is None
+    assert flush_usage_telemetry() == 0
+
+
+def test_sync_request_records_success_and_failure_without_content() -> None:
+    client = _sync_client()
+    success_response = _response(
+        payload={
+            "choices": [{"message": {"content": "private response"}}],
+            "usage": {"prompt_tokens": 9, "completion_tokens": 4},
+        }
+    )
+    with (
+        patch.object(client, "_post", return_value=(success_response, Mock())),
+        patch.object(client, "_wait", return_value=success_response),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+    ):
+        assert (
+            client.get_req({"messages": [{"content": "private prompt"}]})
+            is success_response
+        )
+    assert record.call_count == 1
+    kwargs = record.call_args.kwargs
+    assert kwargs["success"] is True
+    assert kwargs["usage"] == _TokenUsage(9, 4, True)
+    assert "private" not in repr(kwargs)
+
+    failure_response = _response(status=429)
+    client.last_response = failure_response
+    with (
+        patch.object(client, "_post", side_effect=RuntimeError("private exception")),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+        pytest.raises(RuntimeError, match="private exception"),
+    ):
+        client.get_req({"messages": [{"content": "private prompt"}]})
+    kwargs = record.call_args.kwargs
+    assert kwargs["success"] is False
+    assert kwargs["error_category"] == "rate_limited"
+    assert "private" not in repr(kwargs)
+
+
+def test_telemetry_failures_do_not_change_user_request_result() -> None:
+    client = _sync_client()
+    response = _response(payload={"usage": {"prompt_tokens": 1}})
+    with (
+        patch.object(client, "_post", return_value=(response, Mock())),
+        patch.object(client, "_wait", return_value=response),
+        patch(
+            "langchain_nvidia_ai_endpoints._common.record_usage",
+            side_effect=RuntimeError("telemetry failed"),
+        ),
+    ):
+        assert client.get_req({"messages": []}) is response
+
+    with (
+        patch.object(client, "_post", side_effect=ValueError("request failed")),
+        patch(
+            "langchain_nvidia_ai_endpoints._common.record_usage",
+            side_effect=RuntimeError("telemetry failed"),
+        ),
+        pytest.raises(ValueError, match="request failed"),
+    ):
+        client.get_req({"messages": []})
+
+
+def test_sync_stream_records_usage_and_cancellation() -> None:
+    client = _sync_client()
+    response = SimpleNamespace(
+        status_code=200,
+        raise_for_status=lambda: None,
+        iter_lines=lambda: iter([b"data: chunk", b"data: [DONE]"]),
+    )
+    session = Mock()
+    session.post.return_value = response
+    client.get_session_fn = lambda: session
+    with (
+        patch.object(
+            _NVIDIASyncClient,
+            "postprocess",
+            return_value=(
+                {"usage": {"prompt_tokens": 5, "completion_tokens": 3}},
+                False,
+            ),
+        ),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+    ):
+        assert list(client.get_req_stream({"messages": []}))
+    assert record.call_args.kwargs["success"] is True
+    assert record.call_args.kwargs["usage"] == _TokenUsage(5, 3, True)
+
+    response = SimpleNamespace(
+        status_code=200,
+        raise_for_status=lambda: None,
+        iter_lines=lambda: iter([b"data: first", b"data: second"]),
+    )
+    session.post.return_value = response
+    with (
+        patch.object(_NVIDIASyncClient, "postprocess", return_value=({}, False)),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+    ):
+        stream = cast(
+            Generator[dict, Any, Any],
+            client.get_req_stream({"messages": []}),
+        )
+        next(stream)
+        stream.close()
+    assert record.call_args.kwargs["success"] is False
+    assert record.call_args.kwargs["error_category"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_async_request_records_success() -> None:
+    client = _async_client()
+    response = SimpleNamespace(
+        status=200,
+        text=AsyncMock(
+            return_value=json.dumps(
+                {"usage": {"prompt_tokens": 6, "completion_tokens": 2}}
+            )
+        ),
+    )
+    session = SimpleNamespace(close=AsyncMock())
+    with (
+        patch.object(
+            client, "_post_async", AsyncMock(return_value=(response, session))
+        ),
+        patch.object(client, "_wait_async", AsyncMock(return_value=response)),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+    ):
+        await client.aget_req({"messages": []})
+    assert record.call_args.kwargs["success"] is True
+    assert record.call_args.kwargs["usage"] == _TokenUsage(6, 2, True)
+    session.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_stream_records_usage_and_cancellation() -> None:
+    class Reader:
+        def __init__(self, lines: list[bytes]) -> None:
+            self.lines = iter(lines)
+
+        async def readline(self) -> bytes:
+            return next(self.lines, b"")
+
+    client = _async_client()
+    response = SimpleNamespace(
+        status=200,
+        content=Reader([b"data: chunk", b"data: [DONE]"]),
+    )
+    session = SimpleNamespace(post=AsyncMock(return_value=response), close=AsyncMock())
+    client.get_async_session_fn = lambda: session
+    with (
+        patch.object(
+            _NVIDIAAsyncClient,
+            "postprocess",
+            return_value=(
+                {"usage": {"prompt_tokens": 8, "completion_tokens": 3}},
+                False,
+            ),
+        ),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+    ):
+        assert [item async for item in client.aget_req_stream({"messages": []})]
+    assert record.call_args.kwargs["success"] is True
+    assert record.call_args.kwargs["usage"] == _TokenUsage(8, 3, True)
+
+    response = SimpleNamespace(
+        status=200,
+        content=Reader([b"data: first", b"data: second"]),
+    )
+    session.post = AsyncMock(return_value=response)
+    with (
+        patch.object(_NVIDIAAsyncClient, "postprocess", return_value=({}, False)),
+        patch("langchain_nvidia_ai_endpoints._common.record_usage") as record,
+    ):
+        stream = cast(
+            AsyncGenerator[dict, None],
+            client.aget_req_stream({"messages": []}),
+        )
+        await anext(stream)
+        await stream.aclose()
+    assert record.call_args.kwargs["success"] is False
+    assert record.call_args.kwargs["error_category"] == "cancelled"
+
+
+def test_transport_failures_never_escape() -> None:
+    with patch(
+        "langchain_nvidia_ai_endpoints._telemetry.requests.post",
+        side_effect=requests.ConnectionError("private network detail"),
+    ):
+        _post_envelope(
+            "https://events.example.test/v1.1/events/json",
+            {"events": []},
+        )
+
+
+@pytest.mark.parametrize(
+    ("client", "expected"),
+    [
+        (
+            ChatNVIDIA(
+                model="nvidia/nemotron-3.5-lightning-30b-a3b",
+                api_key="test",
+                usage_telemetry_enabled=True,
+            ),
+            True,
+        ),
+        (
+            NVIDIAEmbeddings(api_key="test", usage_telemetry_enabled=True),
+            True,
+        ),
+        (
+            NVIDIA(api_key="test", usage_telemetry_enabled=True),
+            True,
+        ),
+        (
+            NVIDIARerank(api_key="test", usage_telemetry_enabled=True),
+            True,
+        ),
+        (
+            ChatNVIDIA(
+                model="nvidia/nemotron-3.5-lightning-30b-a3b",
+                api_key="test",
+                usage_telemetry_enabled=False,
+            ),
+            False,
+        ),
+    ],
+)
+def test_public_clients_propagate_explicit_opt_in(client: Any, expected: bool) -> None:
+    assert client._client.usage_telemetry_enabled is expected
+    assert client._async_client.usage_telemetry_enabled is expected

--- a/libs/ai-endpoints/tests/unit_tests/test_usage_telemetry.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_usage_telemetry.py
@@ -17,10 +17,12 @@ from langchain_nvidia_ai_endpoints._common import (
 from langchain_nvidia_ai_endpoints._telemetry import (
     _post_envelope,
     _TokenUsage,
+    _TransportDelivery,
     _UsageTelemetry,
     canonical_model_identity,
     classify_error,
     flush_usage_telemetry,
+    http_status_class,
     merge_token_usage,
     operation_for_client,
     record_usage,
@@ -142,6 +144,14 @@ def test_error_classification_uses_status_and_exception_type() -> None:
     assert classify_error(None, ValueError("private prompt")) == "client_validation"
 
 
+def test_http_status_class_uses_closed_buckets() -> None:
+    assert http_status_class(SimpleNamespace(status_code=200)) == "2xx"
+    assert http_status_class(SimpleNamespace(status_code=429)) == "4xx"
+    assert http_status_class(SimpleNamespace(status_code=503)) == "5xx"
+    assert http_status_class(SimpleNamespace(status_code=302)) == "unknown"
+    assert http_status_class(None) == "none"
+
+
 def test_aggregate_flush_matches_schema_and_has_no_identity_values() -> None:
     captured: list[dict] = []
     fixed_now = datetime(2026, 8, 28, 14, 30, tzinfo=timezone.utc)
@@ -156,12 +166,16 @@ def test_aggregate_flush_matches_schema_and_has_no_identity_values() -> None:
         model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
         success=True,
         usage=_TokenUsage(100, 50, True),
+        http_status="2xx",
+        latency_seconds=0.2,
     )
     state.record(
         client_name="ChatNVIDIA",
         model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
         success=True,
         usage=_TokenUsage(20, 10, True),
+        http_status="2xx",
+        latency_seconds=0.4,
     )
     state.record(
         client_name="ChatNVIDIA",
@@ -169,13 +183,15 @@ def test_aggregate_flush_matches_schema_and_has_no_identity_values() -> None:
         success=False,
         usage=_TokenUsage(),
         error_category="authorization",
+        http_status="4xx",
+        latency_seconds=1.2,
     )
 
     assert state.flush(include_current=True) == 2
     assert len(captured) == 1
     envelope = captured[0]
     assert envelope["clientId"] == "623344073512268"
-    assert envelope["eventSchemaVer"] == "0.1"
+    assert envelope["eventSchemaVer"] == "0.2"
     for field in ("userId", "externalUserId", "idpId", "sessionId", "deviceId"):
         assert envelope[field] == "undefined"
 
@@ -187,11 +203,26 @@ def test_aggregate_flush_matches_schema_and_has_no_identity_values() -> None:
         for event in events
         if event["parameters"]["errorCategory"] == "none"
     )
+    assert success["telemetryClientVersion"] == "1.0"
+    assert success["executionMode"] == "sync"
     assert success["requestCount"] == 2
     assert success["successCount"] == 2
     assert success["failureCount"] == 0
+    assert success["cancelledCount"] == 0
+    assert success["partialCount"] == 0
+    assert success["firstAttemptSuccessCount"] == 2
+    assert success["retriedRequestCount"] == 0
     assert success["inputTokenSum"] == 120
     assert success["outputTokenSum"] == 60
+    assert success["missingTokenAttemptCount"] == 0
+    assert success["errorCategoryCounts"]["authorization"] == 0
+    assert success["httpStatusClassCounts"]["2xx"] == 2
+    assert sum(success["latencyBucketCounts"].values()) == 2
+    assert sum(success["ttftBucketCounts"].values()) == 0
+    assert success["missingTtftCount"] == 0
+    assert success["clientDropCount"] == 0
+    assert success["transportRetryCount"] == 0
+    assert success["priorTerminalSendFailureCount"] == 0
     failure = next(
         event["parameters"]
         for event in events
@@ -202,6 +233,10 @@ def test_aggregate_flush_matches_schema_and_has_no_identity_values() -> None:
     assert failure["successCount"] == 0
     assert failure["failureCount"] == 1
     assert failure["missingTokenCount"] == 1
+    assert failure["missingTokenAttemptCount"] == 1
+    assert failure["errorCategoryCounts"]["authorization"] == 1
+    assert failure["httpStatusClassCounts"]["4xx"] == 1
+    assert sum(failure["latencyBucketCounts"].values()) == 1
 
     schema = json.loads(
         (
@@ -244,9 +279,18 @@ def test_aggregate_bucket_count_is_bounded() -> None:
         success=True,
         usage=_TokenUsage(found=False),
     )
+    state.record(
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(found=False),
+    )
 
     assert state.flush(include_current=True) == 1
     assert len(captured[0]["events"]) == 1
+    parameters = captured[0]["events"][0]["parameters"]
+    assert parameters["requestCount"] == 2
+    assert parameters["clientDropCount"] == 1
 
 
 def test_disabled_and_self_hosted_records_do_not_create_global_state(
@@ -306,6 +350,9 @@ def test_sync_request_records_success_and_failure_without_content() -> None:
     kwargs = record.call_args.kwargs
     assert kwargs["success"] is True
     assert kwargs["usage"] == _TokenUsage(9, 4, True)
+    assert kwargs["execution_mode"] == "sync"
+    assert kwargs["http_status"] == "2xx"
+    assert kwargs["latency_seconds"] >= 0
     assert "private" not in repr(kwargs)
 
     failure_response = _response(status=429)
@@ -319,6 +366,9 @@ def test_sync_request_records_success_and_failure_without_content() -> None:
     kwargs = record.call_args.kwargs
     assert kwargs["success"] is False
     assert kwargs["error_category"] == "rate_limited"
+    assert kwargs["execution_mode"] == "sync"
+    assert kwargs["http_status"] == "4xx"
+    assert kwargs["latency_seconds"] >= 0
     assert "private" not in repr(kwargs)
 
 
@@ -370,6 +420,9 @@ def test_sync_stream_records_usage_and_cancellation() -> None:
         assert list(client.get_req_stream({"messages": []}))
     assert record.call_args.kwargs["success"] is True
     assert record.call_args.kwargs["usage"] == _TokenUsage(5, 3, True)
+    assert record.call_args.kwargs["execution_mode"] == "streaming"
+    assert record.call_args.kwargs["http_status"] == "2xx"
+    assert record.call_args.kwargs["ttft_seconds"] is not None
 
     response = SimpleNamespace(
         status_code=200,
@@ -389,6 +442,9 @@ def test_sync_stream_records_usage_and_cancellation() -> None:
         stream.close()
     assert record.call_args.kwargs["success"] is False
     assert record.call_args.kwargs["error_category"] == "cancelled"
+    assert record.call_args.kwargs["execution_mode"] == "streaming"
+    assert record.call_args.kwargs["partial"] is True
+    assert record.call_args.kwargs["ttft_seconds"] is not None
 
 
 @pytest.mark.asyncio
@@ -413,6 +469,7 @@ async def test_async_request_records_success() -> None:
         await client.aget_req({"messages": []})
     assert record.call_args.kwargs["success"] is True
     assert record.call_args.kwargs["usage"] == _TokenUsage(6, 2, True)
+    assert record.call_args.kwargs["execution_mode"] == "async"
     session.close.assert_awaited_once()
 
 
@@ -446,6 +503,9 @@ async def test_async_stream_records_usage_and_cancellation() -> None:
         assert [item async for item in client.aget_req_stream({"messages": []})]
     assert record.call_args.kwargs["success"] is True
     assert record.call_args.kwargs["usage"] == _TokenUsage(8, 3, True)
+    assert record.call_args.kwargs["execution_mode"] == "streaming"
+    assert record.call_args.kwargs["http_status"] == "2xx"
+    assert record.call_args.kwargs["ttft_seconds"] is not None
 
     response = SimpleNamespace(
         status=200,
@@ -464,17 +524,63 @@ async def test_async_stream_records_usage_and_cancellation() -> None:
         await stream.aclose()
     assert record.call_args.kwargs["success"] is False
     assert record.call_args.kwargs["error_category"] == "cancelled"
+    assert record.call_args.kwargs["execution_mode"] == "streaming"
+    assert record.call_args.kwargs["partial"] is True
+    assert record.call_args.kwargs["ttft_seconds"] is not None
 
 
 def test_transport_failures_never_escape() -> None:
-    with patch(
-        "langchain_nvidia_ai_endpoints._telemetry.requests.post",
-        side_effect=requests.ConnectionError("private network detail"),
+    with (
+        patch(
+            "langchain_nvidia_ai_endpoints._telemetry.requests.post",
+            side_effect=requests.ConnectionError("private network detail"),
+        ),
+        patch("langchain_nvidia_ai_endpoints._telemetry.time.sleep"),
     ):
-        _post_envelope(
+        delivery = _post_envelope(
             "https://events.example.test/v1.1/events/json",
             {"events": []},
         )
+    assert delivery == _TransportDelivery(retry_count=2, terminal_failure=True)
+
+
+def test_transport_delivery_health_is_reported_on_next_batch() -> None:
+    captured: list[dict] = []
+
+    def post(endpoint: str, payload: dict) -> _TransportDelivery:
+        captured.append(payload)
+        if len(captured) == 1:
+            return _TransportDelivery(retry_count=2, terminal_failure=True)
+        return _TransportDelivery()
+
+    state = _UsageTelemetry(
+        endpoint="https://events.example.test/v1.1/events/json",
+        post=post,
+        now=lambda: datetime(2026, 8, 28, 14, 30, tzinfo=timezone.utc),
+        start_worker=False,
+    )
+    state.record(
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(1, 1, True),
+    )
+    assert state.flush(include_current=True) == 1
+
+    state.record(
+        client_name="ChatNVIDIA",
+        model_name="nvidia/nemotron-3.5-lightning-30b-a3b",
+        success=True,
+        usage=_TokenUsage(1, 1, True),
+    )
+    assert state.flush(include_current=True) == 1
+
+    first = captured[0]["events"][0]["parameters"]
+    second = captured[1]["events"][0]["parameters"]
+    assert first["transportRetryCount"] == 0
+    assert first["priorTerminalSendFailureCount"] == 0
+    assert second["transportRetryCount"] == 2
+    assert second["priorTerminalSendFailureCount"] == 1
 
 
 @pytest.mark.parametrize(

--- a/libs/ai-endpoints/tests/unit_tests/test_usage_telemetry.py
+++ b/libs/ai-endpoints/tests/unit_tests/test_usage_telemetry.py
@@ -79,14 +79,26 @@ def _response(status: int = 200, payload: dict | None = None) -> requests.Respon
     return response
 
 
-def test_usage_telemetry_is_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_usage_telemetry_is_default_on_with_opt_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv("NVIDIA_USAGE_TELEMETRY_ENABLED", raising=False)
-    assert usage_telemetry_enabled() is False
+    assert usage_telemetry_enabled() is True
     assert usage_telemetry_enabled(False) is False
     assert usage_telemetry_enabled(True) is True
 
     monkeypatch.setenv("NVIDIA_USAGE_TELEMETRY_ENABLED", "true")
     assert usage_telemetry_enabled() is True
+    monkeypatch.setenv("NVIDIA_USAGE_TELEMETRY_ENABLED", "1")
+    assert usage_telemetry_enabled() is True
+
+
+@pytest.mark.parametrize("disabled_value", ["0", "false", "False", "no", "off"])
+def test_usage_telemetry_env_opt_out(
+    monkeypatch: pytest.MonkeyPatch, disabled_value: str
+) -> None:
+    monkeypatch.setenv("NVIDIA_USAGE_TELEMETRY_ENABLED", disabled_value)
+    assert usage_telemetry_enabled() is False
 
 
 def test_canonical_model_identity_uses_versioned_static_allowlist() -> None:
@@ -616,6 +628,34 @@ def test_transport_delivery_health_is_reported_on_next_batch() -> None:
         ),
     ],
 )
-def test_public_clients_propagate_explicit_opt_in(client: Any, expected: bool) -> None:
+def test_public_clients_propagate_explicit_setting(client: Any, expected: bool) -> None:
     assert client._client.usage_telemetry_enabled is expected
     assert client._async_client.usage_telemetry_enabled is expected
+
+
+def test_public_client_uses_default_on_and_env_opt_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NVIDIA_USAGE_TELEMETRY_ENABLED", raising=False)
+    default_client = ChatNVIDIA(
+        model="nvidia/nemotron-3.5-lightning-30b-a3b",
+        api_key="test",
+    )
+    assert default_client._client.usage_telemetry_enabled is True
+    assert default_client._async_client.usage_telemetry_enabled is True
+
+    monkeypatch.setenv("NVIDIA_USAGE_TELEMETRY_ENABLED", "false")
+    disabled_client = ChatNVIDIA(
+        model="nvidia/nemotron-3.5-lightning-30b-a3b",
+        api_key="test",
+    )
+    assert disabled_client._client.usage_telemetry_enabled is False
+    assert disabled_client._async_client.usage_telemetry_enabled is False
+
+    explicit_client = ChatNVIDIA(
+        model="nvidia/nemotron-3.5-lightning-30b-a3b",
+        api_key="test",
+        usage_telemetry_enabled=True,
+    )
+    assert explicit_client._client.usage_telemetry_enabled is True
+    assert explicit_client._async_client.usage_telemetry_enabled is True


### PR DESCRIPTION
Depends on / stacked after #362.

This follow-up aligns the opt-in NIM usage telemetry payload with the MVP/runtime telemetry contract. Until #362 merges, this PR includes the base telemetry commit plus the v0.2 schema expansion commit.

Summary:
- Expands `nim_client_usage` / SMS schema to v0.2 with execution mode, HTTP status-class counts, latency/TTFT buckets, cancellation/partial counts, client drops, transport retries, and prior terminal send failure counters.
- Populates the new fields from sync, async, and streaming request paths while keeping telemetry default-off, hosted-only, in-memory, and content-free.
- Keeps unexpected telemetry values in closed buckets like `unknown` instead of emitting arbitrary strings.
- Updates README and unit coverage for schema parity, no identity/content retention, UAT endpoint handling, and transport-health counters.

Validation:
- `poetry run pytest tests/unit_tests/test_usage_telemetry.py`
- `poetry run pytest tests/unit_tests`
- `poetry run ruff check langchain_nvidia_ai_endpoints/_telemetry.py langchain_nvidia_ai_endpoints/_common.py tests/unit_tests/test_usage_telemetry.py`
- `poetry run ruff format --check langchain_nvidia_ai_endpoints/_telemetry.py langchain_nvidia_ai_endpoints/_common.py tests/unit_tests/test_usage_telemetry.py`
- `poetry run mypy langchain_nvidia_ai_endpoints/_telemetry.py langchain_nvidia_ai_endpoints/_common.py tests/unit_tests/test_usage_telemetry.py`
- `python3 -m json.tool libs/ai-endpoints/tests/data/nim_client_usage_schema.json`

UAT validation:
- Uploaded SMS schema v0.2 to stage/UAT only.
- Synthetic UAT event indexed with `eventSchemaVer=0.2`.
- Real `ChatNVIDIA` runtime telemetry event indexed with all expected v0.2 parameter fields present.

Note:
Production/default-on rollout remains gated on the NVDP enrichment/privacy follow-up for platform-added fields outside `parameters`, such as `frontendIp`, `client.userAgent`, and `location.*`.